### PR TITLE
프로젝트 통계 요약 조회 시 발생하는 쿼리 개선

### DIFF
--- a/src/main/java/com/prism/statistics/domain/analysis/insight/activity/ReviewActivity.java
+++ b/src/main/java/com/prism/statistics/domain/analysis/insight/activity/ReviewActivity.java
@@ -154,10 +154,6 @@ public class ReviewActivity extends BaseTimeEntity {
         return calculateTotalCodeChangesAfterReview() >= 10;
     }
 
-    public boolean isFirstReviewApproved() {
-        return reviewRoundTrips == 1 && !hasAdditionalReviewers;
-    }
-
     public boolean hasCodeChangesAfterReview() {
         return codeAdditionsAfterReview > 0 || codeDeletionsAfterReview > 0;
     }

--- a/src/main/java/com/prism/statistics/infrastructure/statistics/persistence/StatisticsSummaryRepositoryAdapter.java
+++ b/src/main/java/com/prism/statistics/infrastructure/statistics/persistence/StatisticsSummaryRepositoryAdapter.java
@@ -1,33 +1,5 @@
 package com.prism.statistics.infrastructure.statistics.persistence;
 
-import com.prism.statistics.domain.analysis.insight.activity.ReviewActivity;
-import com.prism.statistics.domain.analysis.insight.bottleneck.PullRequestBottleneck;
-import com.prism.statistics.domain.analysis.insight.lifecycle.PullRequestLifecycle;
-import com.prism.statistics.domain.analysis.insight.review.ReviewSession;
-import com.prism.statistics.domain.analysis.insight.size.PullRequestSize;
-import com.prism.statistics.domain.analysis.insight.size.enums.SizeGrade;
-import com.prism.statistics.domain.analysis.metadata.pullrequest.PullRequest;
-import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
-import com.prism.statistics.domain.statistics.repository.StatisticsSummaryRepository;
-import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto;
-import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto.BottleneckDto;
-import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto.OverviewDto;
-import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto.ReviewHealthDto;
-import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto.TeamActivityDto;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import static com.prism.statistics.domain.analysis.insight.activity.QReviewActivity.reviewActivity;
 import static com.prism.statistics.domain.analysis.insight.bottleneck.QPullRequestBottleneck.pullRequestBottleneck;
 import static com.prism.statistics.domain.analysis.insight.lifecycle.QPullRequestLifecycle.pullRequestLifecycle;
@@ -35,12 +7,36 @@ import static com.prism.statistics.domain.analysis.insight.review.QReviewSession
 import static com.prism.statistics.domain.analysis.insight.size.QPullRequestSize.pullRequestSize;
 import static com.prism.statistics.domain.analysis.metadata.pullrequest.QPullRequest.pullRequest;
 
+import com.prism.statistics.domain.analysis.insight.size.enums.SizeGrade;
+import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
+import com.prism.statistics.domain.statistics.repository.StatisticsSummaryRepository;
+import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto;
+import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto.BottleneckDto;
+import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto.OverviewDto;
+import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto.ReviewHealthDto;
+import com.prism.statistics.domain.statistics.repository.dto.StatisticsSummaryDto.TeamActivityDto;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
 @Repository
 @RequiredArgsConstructor
 public class StatisticsSummaryRepositoryAdapter implements StatisticsSummaryRepository {
 
-    private final JPAQueryFactory queryFactory;
     private static final String NOT_AVAILABLE_GRADE = "N/A";
+
+    private final JPAQueryFactory queryFactory;
 
     @Override
     @Transactional(readOnly = true)
@@ -49,250 +45,311 @@ public class StatisticsSummaryRepositoryAdapter implements StatisticsSummaryRepo
             LocalDate startDate,
             LocalDate endDate
     ) {
-        List<Long> pullRequestIds = fetchPullRequestIds(projectId, startDate, endDate);
+        long totalPrCount = fetchTotalPrCount(projectId, startDate, endDate);
 
-        if (pullRequestIds.isEmpty()) {
+        if (totalPrCount == 0L) {
             return Optional.empty();
         }
 
-        List<ReviewActivity> activities = fetchReviewActivities(pullRequestIds);
-        List<PullRequestBottleneck> bottlenecks = fetchPullRequestBottlenecks(pullRequestIds);
+        OverviewDto overview = buildOverviewDto(projectId, startDate, endDate, totalPrCount);
+        ReviewActivityAggregate reviewActivityAggregate = fetchReviewActivityAggregate(projectId, startDate, endDate);
+        BottleneckAggregate bottleneckAggregate = fetchBottleneckAggregate(projectId, startDate, endDate);
 
-        OverviewDto overview = buildOverviewDto(projectId, pullRequestIds, startDate, endDate);
-        ReviewHealthDto reviewHealth = buildReviewHealthDto(pullRequestIds, activities, bottlenecks);
-        TeamActivityDto teamActivity = buildTeamActivityDto(pullRequestIds, activities);
-        BottleneckDto bottleneck = buildBottleneckDto(bottlenecks);
+        ReviewHealthDto reviewHealth = buildReviewHealthDto(
+                projectId,
+                startDate,
+                endDate,
+                totalPrCount,
+                reviewActivityAggregate,
+                bottleneckAggregate
+        );
+        TeamActivityDto teamActivity = buildTeamActivityDto(
+                projectId,
+                startDate,
+                endDate,
+                reviewActivityAggregate
+        );
+        BottleneckDto bottleneck = buildBottleneckDto(bottleneckAggregate);
 
         return Optional.of(new StatisticsSummaryDto(overview, reviewHealth, teamActivity, bottleneck));
     }
 
-    private List<Long> fetchPullRequestIds(Long projectId, LocalDate startDate, LocalDate endDate) {
-        return queryFactory
-                .select(pullRequest.id)
+    private long fetchTotalPrCount(Long projectId, LocalDate startDate, LocalDate endDate) {
+        Long totalPrCount = queryFactory
+                .select(pullRequest.count())
                 .from(pullRequest)
-                .where(
-                        pullRequest.projectId.eq(projectId),
-                        createdAtDateRangeCondition(startDate, endDate)
-                )
-                .fetch();
+                .where(pullRequestScopeCondition(projectId, startDate, endDate))
+                .fetchOne();
+        return totalPrCount != null ? totalPrCount : 0L;
     }
 
-    private OverviewDto buildOverviewDto(
-            Long projectId,
-            List<Long> pullRequestIds,
-            LocalDate startDate,
-            LocalDate endDate
-    ) {
-        List<PullRequest> closedPullRequests = queryFactory
-                .selectFrom(pullRequest)
-                .where(
-                        pullRequest.projectId.eq(projectId),
-                        pullRequest.id.in(pullRequestIds),
-                        pullRequest.state.in(PullRequestState.MERGED, PullRequestState.CLOSED),
-                        closedAtDateRangeCondition(startDate, endDate)
-                )
-                .fetch();
+    private OverviewDto buildOverviewDto(Long projectId, LocalDate startDate, LocalDate endDate, long totalPrCount) {
+        Tuple closedAggregate = fetchClosedOverviewAggregate(projectId, startDate, endDate);
+        long mergedPrCount = nullableLong(closedAggregate, 0);
+        long closedPrCount = nullableLong(closedAggregate, 1);
+        long totalMergeTimeMinutes = nullableLong(closedAggregate, 2);
 
-        long totalPrCount = pullRequestIds.size();
-        long mergedPrCount = closedPullRequests.stream()
-                .filter(pr -> pr.isMerged())
-                .count();
-        long closedPrCount = closedPullRequests.stream()
-                .filter(pr -> pr.isClosed())
-                .count();
-        long totalMergeTimeMinutes = closedPullRequests.stream()
-                .filter(pr -> pr.isMerged())
-                .mapToLong(pr -> pr.calculateMergeTimeMinutes())
-                .sum();
-
-        List<PullRequestSize> sizes = queryFactory
-                .selectFrom(pullRequestSize)
-                .where(pullRequestSize.pullRequestId.in(pullRequestIds))
-                .fetch();
-
-        BigDecimal totalSizeScore = sizes.stream()
-                .map(size -> size.getSizeScore())
-                .reduce(BigDecimal.ZERO, (left, right) -> left.add(right));
-
-        String dominantSizeGrade = findDominantSizeGrade(sizes);
+        SizeAggregate sizeAggregate = fetchSizeAggregate(projectId, startDate, endDate);
 
         return new OverviewDto(
                 totalPrCount,
                 mergedPrCount,
                 closedPrCount,
                 totalMergeTimeMinutes,
-                totalSizeScore,
-                sizes.size(),
-                dominantSizeGrade
+                sizeAggregate.totalSizeScore(),
+                sizeAggregate.sizeMeasuredCount(),
+                sizeAggregate.dominantSizeGrade()
         );
     }
 
-    private String findDominantSizeGrade(List<PullRequestSize> sizes) {
-        if (sizes.isEmpty()) {
-            return NOT_AVAILABLE_GRADE;
-        }
+    private Tuple fetchClosedOverviewAggregate(Long projectId, LocalDate startDate, LocalDate endDate) {
+        NumberExpression<Long> mergeMinutesExpression = new CaseBuilder()
+                .when(
+                        pullRequest.state.eq(PullRequestState.MERGED)
+                                         .and(pullRequest.timing.githubCreatedAt.isNotNull())
+                                         .and(pullRequest.timing.githubMergedAt.isNotNull())
+                )
+                .then(Expressions.numberTemplate(
+                        Long.class,
+                        "timestampdiff(minute, {0}, {1})",
+                        pullRequest.timing.githubCreatedAt,
+                        pullRequest.timing.githubMergedAt
+                ))
+                .otherwise(0L);
 
-        Map<SizeGrade, Long> gradeCounts = sizes.stream()
-                .collect(Collectors.groupingBy(size -> size.getSizeGrade(), Collectors.counting()));
+        return queryFactory
+                .select(
+                        new CaseBuilder()
+                                .when(pullRequest.state.eq(PullRequestState.MERGED)).then(1L)
+                                .otherwise(0L).sumLong().coalesce(0L),
+                        new CaseBuilder()
+                                .when(pullRequest.state.eq(PullRequestState.CLOSED)).then(1L)
+                                .otherwise(0L).sumLong().coalesce(0L),
+                        mergeMinutesExpression.sumLong().coalesce(0L)
+                )
+                .from(pullRequest)
+                .where(
+                        pullRequestScopeCondition(projectId, startDate, endDate),
+                        pullRequest.state.in(PullRequestState.MERGED, PullRequestState.CLOSED),
+                        closedAtDateRangeCondition(startDate, endDate)
+                )
+                .fetchOne();
+    }
 
-        return gradeCounts.entrySet().stream()
-                .max(Comparator.comparingLong(entry -> entry.getValue()))
-                .map(entry -> entry.getKey().name())
-                .orElse(NOT_AVAILABLE_GRADE);
+    private SizeAggregate fetchSizeAggregate(Long projectId, LocalDate startDate, LocalDate endDate) {
+        Tuple summary = queryFactory
+                .select(
+                        pullRequestSize.sizeScore.sumBigDecimal().coalesce(BigDecimal.ZERO),
+                        pullRequestSize.count()
+                )
+                .from(pullRequestSize)
+                .join(pullRequest).on(pullRequest.id.eq(pullRequestSize.pullRequestId))
+                .where(pullRequestScopeCondition(projectId, startDate, endDate))
+                .fetchOne();
+
+        BigDecimal totalSizeScore = summary != null
+                ? summary.get(0, BigDecimal.class)
+                : BigDecimal.ZERO;
+        long sizeMeasuredCount = nullableLong(summary, 1);
+
+        Tuple dominantGrade = queryFactory
+                .select(pullRequestSize.sizeGrade, pullRequestSize.count())
+                .from(pullRequestSize)
+                .join(pullRequest).on(pullRequest.id.eq(pullRequestSize.pullRequestId))
+                .where(pullRequestScopeCondition(projectId, startDate, endDate))
+                .groupBy(pullRequestSize.sizeGrade)
+                .orderBy(pullRequestSize.count().desc(), pullRequestSize.sizeGrade.asc())
+                .limit(1)
+                .fetchOne();
+
+        String dominantSizeGrade = Optional.ofNullable(dominantGrade)
+                                           .map(tuple -> tuple.get(pullRequestSize.sizeGrade))
+                                           .map(SizeGrade::name)
+                                           .orElse(NOT_AVAILABLE_GRADE);
+
+        return new SizeAggregate(totalSizeScore != null ? totalSizeScore : BigDecimal.ZERO, sizeMeasuredCount, dominantSizeGrade);
+    }
+
+    private ReviewActivityAggregate fetchReviewActivityAggregate(Long projectId, LocalDate startDate, LocalDate endDate) {
+        Tuple aggregate = queryFactory
+                .select(
+                        new CaseBuilder()
+                                .when(reviewActivity.totalCommentCount.gt(0).or(reviewActivity.reviewRoundTrips.gt(0))).then(1L)
+                                .otherwise(0L).sumLong().coalesce(0L),
+                        new CaseBuilder()
+                                .when(reviewActivity.reviewRoundTrips.eq(1).and(reviewActivity.hasAdditionalReviewers.isFalse())).then(1L)
+                                .otherwise(0L).sumLong().coalesce(0L),
+                        new CaseBuilder()
+                                .when(reviewActivity.codeAdditionsAfterReview.gt(0).or(reviewActivity.codeDeletionsAfterReview.gt(0))).then(1L)
+                                .otherwise(0L).sumLong().coalesce(0L),
+                        reviewActivity.reviewRoundTrips.sumLong().coalesce(0L),
+                        reviewActivity.totalCommentCount.sumLong().coalesce(0L)
+                )
+                .from(reviewActivity)
+                .join(pullRequest).on(pullRequest.id.eq(reviewActivity.pullRequestId))
+                .where(pullRequestScopeCondition(projectId, startDate, endDate))
+                .fetchOne();
+
+        return new ReviewActivityAggregate(
+                nullableLong(aggregate, 0),
+                nullableLong(aggregate, 1),
+                nullableLong(aggregate, 2),
+                nullableLong(aggregate, 3),
+                nullableLong(aggregate, 4)
+        );
     }
 
     private ReviewHealthDto buildReviewHealthDto(
-            List<Long> pullRequestIds,
-            List<ReviewActivity> activities,
-            List<PullRequestBottleneck> bottlenecks
+            Long projectId,
+            LocalDate startDate,
+            LocalDate endDate,
+            long totalPrCount,
+            ReviewActivityAggregate reviewActivityAggregate,
+            BottleneckAggregate bottleneckAggregate
     ) {
-        List<PullRequestLifecycle> lifecycles = queryFactory
-                .selectFrom(pullRequestLifecycle)
-                .where(pullRequestLifecycle.pullRequestId.in(pullRequestIds))
-                .fetch();
-
-        long totalPrCount = pullRequestIds.size();
-        long reviewedPrCount = activities.stream()
-                .filter(a -> a.getTotalCommentCount() > 0 || a.getReviewRoundTrips() > 0)
-                .count();
-
-        long totalReviewWaitMinutes = bottlenecks.stream()
-                .filter(b -> b.getReviewWait() != null)
-                .mapToLong(b -> b.getReviewWait().getMinutes())
-
-                .sum();
-
-        long firstReviewApproveCount = activities.stream()
-                .filter(activity -> activity.isFirstReviewApproved())
-                .count();
-
-        long changesRequestedCount = activities.stream()
-                .filter(activity -> activity.hasCodeChangesAfterReview())
-                .count();
-
-        long closedWithoutReviewCount = lifecycles.stream()
-                .filter(lifecycle -> lifecycle.isClosedWithoutReview())
-                .count();
+        Long closedWithoutReviewCount = queryFactory
+                .select(pullRequestLifecycle.count())
+                .from(pullRequestLifecycle)
+                .join(pullRequest).on(pullRequest.id.eq(pullRequestLifecycle.pullRequestId))
+                .where(
+                        pullRequestScopeCondition(projectId, startDate, endDate),
+                        pullRequestLifecycle.closedWithoutReview.isTrue()
+                )
+                .fetchOne();
 
         return new ReviewHealthDto(
                 totalPrCount,
-                reviewedPrCount,
-                totalReviewWaitMinutes,
-                firstReviewApproveCount,
-                changesRequestedCount,
-                closedWithoutReviewCount
+                reviewActivityAggregate.reviewedPrCount(),
+                bottleneckAggregate.totalReviewWaitMinutes(),
+                reviewActivityAggregate.firstReviewApproveCount(),
+                reviewActivityAggregate.changesRequestedCount(),
+                closedWithoutReviewCount != null ? closedWithoutReviewCount : 0L
         );
     }
 
-    private TeamActivityDto buildTeamActivityDto(List<Long> pullRequestIds, List<ReviewActivity> activities) {
-        List<ReviewSession> sessions = queryFactory
-                .selectFrom(reviewSession)
-                .where(reviewSession.pullRequestId.in(pullRequestIds))
+    private TeamActivityDto buildTeamActivityDto(
+            Long projectId,
+            LocalDate startDate,
+            LocalDate endDate,
+            ReviewActivityAggregate reviewActivityAggregate
+    ) {
+        Long uniquePullRequestCountResult = queryFactory
+                .select(pullRequest.count())
+                .from(pullRequest)
+                .where(
+                        pullRequestScopeCondition(projectId, startDate, endDate),
+                        JPAExpressions
+                                .selectOne()
+                                .from(reviewSession)
+                                .where(reviewSession.pullRequestId.eq(pullRequest.id))
+                                .exists()
+                )
+                .fetchOne();
+        long uniquePullRequestCount = uniquePullRequestCountResult != null ? uniquePullRequestCountResult : 0L;
+
+        List<Long> reviewerAssignmentCounts = queryFactory
+                .select(reviewSession.count())
+                .from(reviewSession)
+                .where(
+                        JPAExpressions
+                                .selectOne()
+                                .from(pullRequest)
+                                .where(
+                                        pullRequest.id.eq(reviewSession.pullRequestId),
+                                        pullRequestScopeCondition(projectId, startDate, endDate)
+                                )
+                                .exists()
+                )
+                .groupBy(reviewSession.reviewer.userId)
                 .fetch();
 
-        long uniqueReviewerCount = sessions.stream()
-                .map(s -> s.getReviewer().getUserId())
-                .distinct()
-                .count();
+        long uniqueReviewerCount = reviewerAssignmentCounts.size();
+        long totalReviewerAssignments = reviewerAssignmentCounts.stream()
+                                                                .mapToLong(Long::longValue)
+                                                                .sum();
 
-        long uniquePullRequestCount = sessions.stream()
-                .map(session -> session.getPullRequestId())
-                .distinct()
-                .count();
-
-        long totalReviewerAssignments = sessions.size();
-
-        long totalReviewRoundTrips = activities.stream()
-                .mapToLong(activity -> activity.getReviewRoundTrips())
-                .sum();
-
-        long totalCommentCount = activities.stream()
-                .mapToLong(activity -> activity.getTotalCommentCount())
-                .sum();
-
-        double giniCoefficient = calculateGiniCoefficient(sessions);
+        double giniCoefficient = calculateGiniCoefficient(reviewerAssignmentCounts);
 
         return new TeamActivityDto(
                 uniqueReviewerCount,
                 uniquePullRequestCount,
                 totalReviewerAssignments,
-                totalReviewRoundTrips,
-                totalCommentCount,
+                reviewActivityAggregate.totalReviewRoundTrips(),
+                reviewActivityAggregate.totalCommentCount(),
                 giniCoefficient
         );
     }
 
-    private double calculateGiniCoefficient(List<ReviewSession> sessions) {
-        if (sessions.isEmpty()) {
+    private double calculateGiniCoefficient(List<Long> reviewerAssignmentCounts) {
+        if (reviewerAssignmentCounts.isEmpty()) {
             return 0.0;
         }
 
-        Map<Long, Long> reviewerCounts = sessions.stream()
-                .collect(Collectors.groupingBy(
-                        s -> s.getReviewer().getUserId(),
-                        Collectors.counting()
-                ));
-
-        List<Long> counts = reviewerCounts.values().stream()
-                .sorted()
-                .toList();
+        List<Long> counts = reviewerAssignmentCounts.stream()
+                                                    .sorted()
+                                                    .toList();
 
         int n = counts.size();
         if (n <= 1) {
             return 0.0;
         }
 
-        double totalSum = counts.stream().mapToDouble(value -> value).sum();
-        if (totalSum == 0) {
+        double totalSum = counts.stream()
+                                .mapToDouble(Long::doubleValue)
+                                .sum();
+        if (totalSum == 0.0) {
             return 0.0;
         }
 
-        double cumulativeSum = 0;
-        double giniSum = 0;
+        double giniSum = 0.0;
         for (int i = 0; i < n; i++) {
-            cumulativeSum += counts.get(i);
-            giniSum += (2 * (i + 1) - n - 1) * counts.get(i);
+            giniSum += (2.0 * (i + 1) - n - 1) * counts.get(i);
         }
 
         return giniSum / (n * totalSum);
     }
 
-    private BottleneckDto buildBottleneckDto(List<PullRequestBottleneck> bottlenecks) {
-        long totalReviewWaitMinutes = bottlenecks.stream()
-                .filter(b -> b.getReviewWait() != null)
-                .mapToLong(b -> b.getReviewWait().getMinutes())
-                .sum();
+    private BottleneckAggregate fetchBottleneckAggregate(Long projectId, LocalDate startDate, LocalDate endDate) {
+        Tuple aggregate = queryFactory
+                .select(
+                        pullRequestBottleneck.reviewWait.minutes.sumLong().coalesce(0L),
+                        pullRequestBottleneck.reviewProgress.minutes.sumLong().coalesce(0L),
+                        pullRequestBottleneck.mergeWait.minutes.sumLong().coalesce(0L),
+                        pullRequestBottleneck.count()
+                )
+                .from(pullRequest)
+                .join(pullRequestBottleneck).on(pullRequest.id.eq(pullRequestBottleneck.pullRequestId))
+                .where(pullRequestScopeCondition(projectId, startDate, endDate))
+                .fetchOne();
 
-        long totalReviewProgressMinutes = bottlenecks.stream()
-                .filter(b -> b.getReviewProgress() != null)
-                .mapToLong(b -> b.getReviewProgress().getMinutes())
-                .sum();
-
-        long totalMergeWaitMinutes = bottlenecks.stream()
-                .filter(b -> b.getMergeWait() != null)
-                .mapToLong(b -> b.getMergeWait().getMinutes())
-                .sum();
-
-        return new BottleneckDto(
-                totalReviewWaitMinutes,
-                totalReviewProgressMinutes,
-                totalMergeWaitMinutes,
-                bottlenecks.size()
+        return new BottleneckAggregate(
+                nullableLong(aggregate, 0),
+                nullableLong(aggregate, 1),
+                nullableLong(aggregate, 2),
+                nullableLong(aggregate, 3)
         );
     }
 
-    private List<ReviewActivity> fetchReviewActivities(List<Long> pullRequestIds) {
-        return queryFactory
-                .selectFrom(reviewActivity)
-                .where(reviewActivity.pullRequestId.in(pullRequestIds))
-                .fetch();
+    private BottleneckDto buildBottleneckDto(BottleneckAggregate bottleneckAggregate) {
+        return new BottleneckDto(
+                bottleneckAggregate.totalReviewWaitMinutes(),
+                bottleneckAggregate.totalReviewProgressMinutes(),
+                bottleneckAggregate.totalMergeWaitMinutes(),
+                bottleneckAggregate.bottleneckCount()
+        );
     }
 
-    private List<PullRequestBottleneck> fetchPullRequestBottlenecks(List<Long> pullRequestIds) {
-        return queryFactory
-                .selectFrom(pullRequestBottleneck)
-                .where(pullRequestBottleneck.pullRequestId.in(pullRequestIds))
-                .fetch();
+    private long nullableLong(Tuple tuple, int index) {
+        if (tuple == null) {
+            return 0L;
+        }
+        Number value = tuple.get(index, Number.class);
+        return value != null ? value.longValue() : 0L;
+    }
+
+    private BooleanExpression pullRequestScopeCondition(Long projectId, LocalDate startDate, LocalDate endDate) {
+        return pullRequest.projectId.eq(projectId)
+                                    .and(createdAtDateRangeCondition(startDate, endDate));
     }
 
     private BooleanExpression createdAtDateRangeCondition(LocalDate startDate, LocalDate endDate) {
@@ -302,7 +359,7 @@ public class StatisticsSummaryRepositoryAdapter implements StatisticsSummaryRepo
 
         if (startDate != null && endDate != null) {
             return pullRequest.timing.githubCreatedAt.goe(startDate.atStartOfDay())
-                    .and(pullRequest.timing.githubCreatedAt.lt(endDate.plusDays(1).atStartOfDay()));
+                                                     .and(pullRequest.timing.githubCreatedAt.lt(endDate.plusDays(1).atStartOfDay()));
         }
 
         if (startDate != null) {
@@ -319,7 +376,7 @@ public class StatisticsSummaryRepositoryAdapter implements StatisticsSummaryRepo
 
         if (startDate != null && endDate != null) {
             return pullRequest.timing.githubClosedAt.goe(startDate.atStartOfDay())
-                    .and(pullRequest.timing.githubClosedAt.lt(endDate.plusDays(1).atStartOfDay()));
+                                                    .and(pullRequest.timing.githubClosedAt.lt(endDate.plusDays(1).atStartOfDay()));
         }
 
         if (startDate != null) {
@@ -327,5 +384,29 @@ public class StatisticsSummaryRepositoryAdapter implements StatisticsSummaryRepo
         }
 
         return pullRequest.timing.githubClosedAt.lt(endDate.plusDays(1).atStartOfDay());
+    }
+
+    private record SizeAggregate(
+            BigDecimal totalSizeScore,
+            long sizeMeasuredCount,
+            String dominantSizeGrade
+    ) {
+    }
+
+    private record ReviewActivityAggregate(
+            long reviewedPrCount,
+            long firstReviewApproveCount,
+            long changesRequestedCount,
+            long totalReviewRoundTrips,
+            long totalCommentCount
+    ) {
+    }
+
+    private record BottleneckAggregate(
+            long totalReviewWaitMinutes,
+            long totalReviewProgressMinutes,
+            long totalMergeWaitMinutes,
+            long bottleneckCount
+    ) {
     }
 }

--- a/src/test/java/com/prism/statistics/application/statistics/StatisticsSummaryQueryServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/statistics/StatisticsSummaryQueryServiceTest.java
@@ -191,6 +191,8 @@ class StatisticsSummaryQueryServiceTest {
         // given
         Long userId = 1L;
         Project project = createAndSaveProject(userId);
+        PullRequest pr = createAndSavePullRequest(project.getId(), PullRequestState.MERGED);
+        createAndSaveSize(pr.getId(), BigDecimal.valueOf(100));
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(null, null);
 
         // when
@@ -199,6 +201,7 @@ class StatisticsSummaryQueryServiceTest {
 
         // then
         assertAll(
+                () -> assertThat(actual.overview().totalPrCount()).isEqualTo(1),
                 () -> assertThat(actual.teamActivity().totalReviewerCount()).isZero(),
                 () -> assertThat(actual.teamActivity().avgReviewersPerPr()).isZero(),
                 () -> assertThat(actual.teamActivity().avgReviewRoundTrips()).isZero(),
@@ -211,6 +214,8 @@ class StatisticsSummaryQueryServiceTest {
         // given
         Long userId = 1L;
         Project project = createAndSaveProject(userId);
+        PullRequest pr = createAndSavePullRequest(project.getId(), PullRequestState.MERGED);
+        createAndSaveSize(pr.getId(), BigDecimal.valueOf(100));
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(null, null);
 
         // when
@@ -219,6 +224,7 @@ class StatisticsSummaryQueryServiceTest {
 
         // then
         assertAll(
+                () -> assertThat(actual.overview().totalPrCount()).isEqualTo(1),
                 () -> assertThat(actual.bottleneck().avgReviewWaitMinutes()).isZero(),
                 () -> assertThat(actual.bottleneck().avgReviewProgressMinutes()).isZero(),
                 () -> assertThat(actual.bottleneck().avgMergeWaitMinutes()).isZero(),

--- a/src/test/java/com/prism/statistics/application/statistics/StatisticsSummaryQueryServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/statistics/StatisticsSummaryQueryServiceTest.java
@@ -90,19 +90,19 @@ class StatisticsSummaryQueryServiceTest {
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(null, null);
 
         // when
-        StatisticsSummaryResponse response = statisticsSummaryQueryService
+        StatisticsSummaryResponse actual = statisticsSummaryQueryService
                 .findStatisticsSummary(userId, project.getId(), request);
 
         // then
         assertAll(
-                () -> assertThat(response.overview().totalPrCount()).isEqualTo(2),
-                () -> assertThat(response.overview().mergedPrCount()).isEqualTo(1),
-                () -> assertThat(response.overview().closedPrCount()).isEqualTo(1),
-                () -> assertThat(response.overview().mergeSuccessRate()).isEqualTo(50.0),
-                () -> assertThat(response.overview().avgSizeScore()).isCloseTo(100.0, within(0.01)),
-                () -> assertThat(response.reviewHealth().reviewRate()).isGreaterThan(0),
-                () -> assertThat(response.teamActivity().totalReviewerCount()).isEqualTo(2),
-                () -> assertThat(response.bottleneck().avgReviewWaitMinutes()).isCloseTo(75.0, within(0.01))
+                () -> assertThat(actual.overview().totalPrCount()).isEqualTo(2),
+                () -> assertThat(actual.overview().mergedPrCount()).isEqualTo(1),
+                () -> assertThat(actual.overview().closedPrCount()).isEqualTo(1),
+                () -> assertThat(actual.overview().mergeSuccessRate()).isEqualTo(50.0),
+                () -> assertThat(actual.overview().avgSizeScore()).isCloseTo(100.0, within(0.01)),
+                () -> assertThat(actual.reviewHealth().reviewRate()).isGreaterThan(0),
+                () -> assertThat(actual.teamActivity().totalReviewerCount()).isEqualTo(2),
+                () -> assertThat(actual.bottleneck().avgReviewWaitMinutes()).isCloseTo(75.0, within(0.01))
         );
     }
 
@@ -114,17 +114,17 @@ class StatisticsSummaryQueryServiceTest {
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(null, null);
 
         // when
-        StatisticsSummaryResponse response = statisticsSummaryQueryService
+        StatisticsSummaryResponse actual = statisticsSummaryQueryService
                 .findStatisticsSummary(userId, project.getId(), request);
 
         // then
         assertAll(
-                () -> assertThat(response.overview().totalPrCount()).isZero(),
-                () -> assertThat(response.overview().mergedPrCount()).isZero(),
-                () -> assertThat(response.overview().mergeSuccessRate()).isZero(),
-                () -> assertThat(response.reviewHealth().reviewRate()).isZero(),
-                () -> assertThat(response.teamActivity().totalReviewerCount()).isZero(),
-                () -> assertThat(response.bottleneck().avgReviewWaitMinutes()).isZero()
+                () -> assertThat(actual.overview().totalPrCount()).isZero(),
+                () -> assertThat(actual.overview().mergedPrCount()).isZero(),
+                () -> assertThat(actual.overview().mergeSuccessRate()).isZero(),
+                () -> assertThat(actual.reviewHealth().reviewRate()).isZero(),
+                () -> assertThat(actual.teamActivity().totalReviewerCount()).isZero(),
+                () -> assertThat(actual.bottleneck().avgReviewWaitMinutes()).isZero()
         );
     }
 
@@ -141,11 +141,11 @@ class StatisticsSummaryQueryServiceTest {
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(startDate, endDate);
 
         // when
-        StatisticsSummaryResponse response = statisticsSummaryQueryService
+        StatisticsSummaryResponse actual = statisticsSummaryQueryService
                 .findStatisticsSummary(userId, project.getId(), request);
 
         // then
-        assertThat(response.overview().totalPrCount()).isEqualTo(1);
+        assertThat(actual.overview().totalPrCount()).isEqualTo(1);
     }
 
     @Test
@@ -173,16 +173,16 @@ class StatisticsSummaryQueryServiceTest {
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(null, null);
 
         // when
-        StatisticsSummaryResponse response = statisticsSummaryQueryService
+        StatisticsSummaryResponse actual = statisticsSummaryQueryService
                 .findStatisticsSummary(userId, project.getId(), request);
 
         // then
         assertAll(
-                () -> assertThat(response.overview().mergedPrCount()).isZero(),
-                () -> assertThat(response.overview().closedPrCount()).isEqualTo(1),
-                () -> assertThat(response.overview().mergeSuccessRate()).isZero(),
-                () -> assertThat(response.overview().avgMergeTimeMinutes()).isZero(),
-                () -> assertThat(response.overview().avgSizeScore()).isCloseTo(100.0, within(0.01))
+                () -> assertThat(actual.overview().mergedPrCount()).isZero(),
+                () -> assertThat(actual.overview().closedPrCount()).isEqualTo(1),
+                () -> assertThat(actual.overview().mergeSuccessRate()).isZero(),
+                () -> assertThat(actual.overview().avgMergeTimeMinutes()).isZero(),
+                () -> assertThat(actual.overview().avgSizeScore()).isCloseTo(100.0, within(0.01))
         );
     }
 
@@ -191,20 +191,18 @@ class StatisticsSummaryQueryServiceTest {
         // given
         Long userId = 1L;
         Project project = createAndSaveProject(userId);
-        PullRequest pr = createAndSavePullRequest(project.getId(), PullRequestState.MERGED);
-
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(null, null);
 
         // when
-        StatisticsSummaryResponse response = statisticsSummaryQueryService
+        StatisticsSummaryResponse actual = statisticsSummaryQueryService
                 .findStatisticsSummary(userId, project.getId(), request);
 
         // then
         assertAll(
-                () -> assertThat(response.teamActivity().totalReviewerCount()).isZero(),
-                () -> assertThat(response.teamActivity().avgReviewersPerPr()).isZero(),
-                () -> assertThat(response.teamActivity().avgReviewRoundTrips()).isZero(),
-                () -> assertThat(response.teamActivity().avgCommentCount()).isZero()
+                () -> assertThat(actual.teamActivity().totalReviewerCount()).isZero(),
+                () -> assertThat(actual.teamActivity().avgReviewersPerPr()).isZero(),
+                () -> assertThat(actual.teamActivity().avgReviewRoundTrips()).isZero(),
+                () -> assertThat(actual.teamActivity().avgCommentCount()).isZero()
         );
     }
 
@@ -213,20 +211,18 @@ class StatisticsSummaryQueryServiceTest {
         // given
         Long userId = 1L;
         Project project = createAndSaveProject(userId);
-        PullRequest pr = createAndSavePullRequest(project.getId(), PullRequestState.MERGED);
-
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(null, null);
 
         // when
-        StatisticsSummaryResponse response = statisticsSummaryQueryService
+        StatisticsSummaryResponse actual = statisticsSummaryQueryService
                 .findStatisticsSummary(userId, project.getId(), request);
 
         // then
         assertAll(
-                () -> assertThat(response.bottleneck().avgReviewWaitMinutes()).isZero(),
-                () -> assertThat(response.bottleneck().avgReviewProgressMinutes()).isZero(),
-                () -> assertThat(response.bottleneck().avgMergeWaitMinutes()).isZero(),
-                () -> assertThat(response.bottleneck().totalCycleTimeMinutes()).isZero()
+                () -> assertThat(actual.bottleneck().avgReviewWaitMinutes()).isZero(),
+                () -> assertThat(actual.bottleneck().avgReviewProgressMinutes()).isZero(),
+                () -> assertThat(actual.bottleneck().avgMergeWaitMinutes()).isZero(),
+                () -> assertThat(actual.bottleneck().totalCycleTimeMinutes()).isZero()
         );
     }
 
@@ -244,15 +240,16 @@ class StatisticsSummaryQueryServiceTest {
         StatisticsSummaryRequest request = new StatisticsSummaryRequest(null, null);
 
         // when
-        StatisticsSummaryResponse response = statisticsSummaryQueryService
+        StatisticsSummaryResponse actual = statisticsSummaryQueryService
                 .findStatisticsSummary(userId, project.getId(), request);
 
         // then
-        assertThat(response.reviewHealth().closedWithoutReviewRate()).isCloseTo(50.0, within(0.01));
+        assertThat(actual.reviewHealth().closedWithoutReviewRate()).isCloseTo(50.0, within(0.01));
     }
 
     private Project createAndSaveProject(Long userId) {
         Project project = Project.create("Test Project", "test-api-key-" + System.nanoTime(), userId);
+
         return projectRepository.save(project);
     }
 
@@ -260,7 +257,6 @@ class StatisticsSummaryQueryServiceTest {
         LocalDateTime createdAt = LocalDateTime.now().minusDays(1);
         LocalDateTime closedAt = resolveClosedAt(state);
         PullRequestTiming timing = resolveTiming(state, createdAt, closedAt);
-
         PullRequest pullRequest = PullRequest.builder()
                 .githubPullRequestId(System.nanoTime())
                 .projectId(projectId)
@@ -287,6 +283,7 @@ class StatisticsSummaryQueryServiceTest {
                 0,
                 BigDecimal.valueOf(0.3)
         );
+
         sizeRepository.save(size);
     }
 
@@ -301,6 +298,7 @@ class StatisticsSummaryQueryServiceTest {
                 .totalAdditions(100)
                 .totalDeletions(50)
                 .build();
+
         reviewActivityRepository.save(activity);
     }
 
@@ -310,6 +308,7 @@ class StatisticsSummaryQueryServiceTest {
                 GithubUser.create(reviewerName, reviewerId),
                 LocalDateTime.now().minusHours(1)
         );
+
         reviewSessionRepository.save(session);
     }
 
@@ -324,6 +323,7 @@ class StatisticsSummaryQueryServiceTest {
                 .reopened(false)
                 .closedWithoutReview(closedWithoutReview)
                 .build();
+
         lifecycleRepository.save(lifecycle);
     }
 
@@ -331,6 +331,7 @@ class StatisticsSummaryQueryServiceTest {
         if (state.isClosureState()) {
             return LocalDateTime.now();
         }
+
         return null;
     }
 
@@ -352,7 +353,7 @@ class StatisticsSummaryQueryServiceTest {
         if (closedWithoutReview) {
             return null;
         }
-        return DurationMinutes.of(1440L);
+        return DurationMinutes.of(1_440L);
     }
 
     private void createAndSaveBottleneck(Long pullRequestId, Long reviewWait, Long reviewProgress, Long mergeWait) {

--- a/src/test/java/com/prism/statistics/application/statistics/WeeklyTrendStatisticsQueryServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/statistics/WeeklyTrendStatisticsQueryServiceTest.java
@@ -151,7 +151,7 @@ class WeeklyTrendStatisticsQueryServiceTest {
                 .githubPullRequestId(System.nanoTime())
                 .projectId(projectId)
                 .author(GithubUser.create(TEST_USER_NAME, AUTHOR_USER_ID))
-                .pullRequestNumber((int) (Math.abs(System.nanoTime() % PULL_REQUEST_NUMBER_MODULUS)))
+                .pullRequestNumber((int) (Math.abs(System.nanoTime() % PULL_REQUEST_NUMBER_MODULUS)) + 1)
                 .headCommitSha(TEST_HEAD_SHA)
                 .title(TEST_PULL_REQUEST_TITLE)
                 .state(state)


### PR DESCRIPTION
# 관련 이슈 번호
<!-- 해당 PR이 merge되면 닫힐 이슈 번호를 명시해주세요. -->
- closed #129 

## 이 PR을 통해 해결하려는 문제가 무엇인가요?

<!-- 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요. -->
<!-- 일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요. -->

프로젝트 통계 요약 조회 시 발생하는 쿼리에서 다음과 같은 문제를 해결했습니다

- 해당 통계에 필요 없는 필드까지 모두 조회
- 기본적인 통계까지 모두 애플리케이션 레벨에서 수행
- 제한 없는 IN절 수행

이 과정에서 다음과 같이 API 실행 시간을 개선했습니다 

- 개선 전
  - 최대 23225ms / 최소 19564ms / 중간 21477ms
- 개선 후
  - 최대 56ms / 최소 23ms / 중간 31ms

## 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요. -->

- StatisticsSummaryRepositoryAdapter에서 발생하는 쿼리

## 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
<!-- 없으면 "없음" 이라고 기재해 주세요 -->

- StatisticsSummaryQueryServiceTest 테스트 일부를 리팩터링 했습니다 
- DB에서 기본적인 통계를 진행하는 방식으로 변경되면서 사용되지 않는 도메인 로직을 삭제했습니다 

## Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
<!-- 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요. -->
