### PR TITLE
CollectFacade 도입으로 apiKey 변환 로직 격리 

### DIFF
--- a/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestClosedService.java
+++ b/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestClosedService.java
@@ -6,8 +6,6 @@ import com.prism.statistics.application.analysis.metadata.utils.LocalDateTimeCon
 import com.prism.statistics.domain.analysis.metadata.pullrequest.PullRequest;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.repository.PullRequestRepository;
-import com.prism.statistics.domain.project.repository.ProjectRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -22,15 +20,11 @@ import java.time.LocalDateTime;
 public class PullRequestClosedService {
 
     private final LocalDateTimeConverter localDateTimeConverter;
-    private final ProjectRepository projectRepository;
     private final PullRequestRepository pullRequestRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public void closePullRequest(String apiKey, PullRequestClosedRequest request) {
-        Long projectId = projectRepository.findIdByApiKey(apiKey)
-                .orElseThrow(() -> new InvalidApiKeyException());
-
+    public void closePullRequest(Long projectId, PullRequestClosedRequest request) {
         pullRequestRepository.findPullRequest(projectId, request.pullRequestNumber())
                 .ifPresentOrElse(
                         pullRequest -> processClosed(pullRequest, request),

--- a/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestConvertedToDraftService.java
+++ b/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestConvertedToDraftService.java
@@ -6,8 +6,6 @@ import com.prism.statistics.application.analysis.metadata.utils.LocalDateTimeCon
 import com.prism.statistics.domain.analysis.metadata.pullrequest.PullRequest;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.repository.PullRequestRepository;
-import com.prism.statistics.domain.project.repository.ProjectRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -22,15 +20,11 @@ import java.time.LocalDateTime;
 public class PullRequestConvertedToDraftService {
 
     private final LocalDateTimeConverter localDateTimeConverter;
-    private final ProjectRepository projectRepository;
     private final PullRequestRepository pullRequestRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public void convertToDraft(String apiKey, PullRequestConvertedToDraftRequest request) {
-        Long projectId = projectRepository.findIdByApiKey(apiKey)
-                .orElseThrow(() -> new InvalidApiKeyException());
-
+    public void convertToDraft(Long projectId, PullRequestConvertedToDraftRequest request) {
         pullRequestRepository.findPullRequest(projectId, request.pullRequestNumber())
                 .ifPresentOrElse(
                         pullRequest -> processConvertedToDraft(pullRequest, request),

--- a/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestOpenedService.java
+++ b/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestOpenedService.java
@@ -7,14 +7,12 @@ import com.prism.statistics.application.analysis.metadata.pullrequest.event.Pull
 import com.prism.statistics.application.analysis.metadata.pullrequest.event.PullRequestSavedEvent;
 import com.prism.statistics.application.analysis.metadata.pullrequest.event.PullRequestOpenCreatedEvent.CommitData;
 import com.prism.statistics.application.analysis.metadata.utils.LocalDateTimeConverter;
-import com.prism.statistics.domain.project.repository.ProjectRepository;
 import com.prism.statistics.domain.analysis.metadata.common.vo.GithubUser;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.PullRequest;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.repository.PullRequestRepository;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.vo.PullRequestChangeStats;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.vo.PullRequestTiming;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -28,15 +26,11 @@ import java.util.List;
 public class PullRequestOpenedService {
 
     private final LocalDateTimeConverter localDateTimeConverter;
-    private final ProjectRepository projectRepository;
     private final PullRequestRepository pullRequestRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public void createPullRequest(String apiKey, PullRequestOpenedRequest request) {
-        Long projectId = projectRepository.findIdByApiKey(apiKey)
-                .orElseThrow(() -> new InvalidApiKeyException());
-
+    public void createPullRequest(Long projectId, PullRequestOpenedRequest request) {
         if (request.isDraft()) {
             createDraftPullRequest(projectId, request);
             return;

--- a/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestReadyForReviewService.java
+++ b/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestReadyForReviewService.java
@@ -6,8 +6,6 @@ import com.prism.statistics.application.analysis.metadata.utils.LocalDateTimeCon
 import com.prism.statistics.domain.analysis.metadata.pullrequest.PullRequest;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.repository.PullRequestRepository;
-import com.prism.statistics.domain.project.repository.ProjectRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -22,15 +20,11 @@ import java.time.LocalDateTime;
 public class PullRequestReadyForReviewService {
 
     private final LocalDateTimeConverter localDateTimeConverter;
-    private final ProjectRepository projectRepository;
     private final PullRequestRepository pullRequestRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public void readyForReview(String apiKey, PullRequestReadyForReviewRequest request) {
-        Long projectId = projectRepository.findIdByApiKey(apiKey)
-                .orElseThrow(() -> new InvalidApiKeyException());
-
+    public void readyForReview(Long projectId, PullRequestReadyForReviewRequest request) {
         pullRequestRepository.findPullRequest(projectId, request.pullRequestNumber())
                 .ifPresentOrElse(
                         pullRequest -> processReadyForReview(pullRequest, request),

--- a/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestReopenedService.java
+++ b/src/main/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestReopenedService.java
@@ -6,8 +6,6 @@ import com.prism.statistics.application.analysis.metadata.utils.LocalDateTimeCon
 import com.prism.statistics.domain.analysis.metadata.pullrequest.PullRequest;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.repository.PullRequestRepository;
-import com.prism.statistics.domain.project.repository.ProjectRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -22,15 +20,11 @@ import java.time.LocalDateTime;
 public class PullRequestReopenedService {
 
     private final LocalDateTimeConverter localDateTimeConverter;
-    private final ProjectRepository projectRepository;
     private final PullRequestRepository pullRequestRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public void reopenPullRequest(String apiKey, PullRequestReopenedRequest request) {
-        Long projectId = projectRepository.findIdByApiKey(apiKey)
-                .orElseThrow(() -> new InvalidApiKeyException());
-
+    public void reopenPullRequest(Long projectId, PullRequestReopenedRequest request) {
         pullRequestRepository.findPullRequest(projectId, request.pullRequestNumber())
                 .ifPresentOrElse(
                         pullRequest -> processReopened(pullRequest, request),

--- a/src/main/java/com/prism/statistics/application/collect/CollectFacade.java
+++ b/src/main/java/com/prism/statistics/application/collect/CollectFacade.java
@@ -1,0 +1,51 @@
+package com.prism.statistics.application.collect;
+
+import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestClosedService;
+import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestConvertedToDraftService;
+import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestOpenedService;
+import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestReadyForReviewService;
+import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestReopenedService;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestClosedRequest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestConvertedToDraftRequest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReadyForReviewRequest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReopenedRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CollectFacade {
+
+    private final ProjectApiKeyService projectApiKeyService;
+    private final PullRequestOpenedService pullRequestOpenedService;
+    private final PullRequestClosedService pullRequestClosedService;
+    private final PullRequestReadyForReviewService pullRequestReadyForReviewService;
+    private final PullRequestReopenedService pullRequestReopenedService;
+    private final PullRequestConvertedToDraftService pullRequestConvertedToDraftService;
+
+    public void createPullRequest(String apiKey, PullRequestOpenedRequest request) {
+        Long projectId = projectApiKeyService.resolveProjectId(apiKey);
+        pullRequestOpenedService.createPullRequest(projectId, request);
+    }
+
+    public void closePullRequest(String apiKey, PullRequestClosedRequest request) {
+        Long projectId = projectApiKeyService.resolveProjectId(apiKey);
+        pullRequestClosedService.closePullRequest(projectId, request);
+    }
+
+    public void readyForReview(String apiKey, PullRequestReadyForReviewRequest request) {
+        Long projectId = projectApiKeyService.resolveProjectId(apiKey);
+        pullRequestReadyForReviewService.readyForReview(projectId, request);
+    }
+
+    public void reopenPullRequest(String apiKey, PullRequestReopenedRequest request) {
+        Long projectId = projectApiKeyService.resolveProjectId(apiKey);
+        pullRequestReopenedService.reopenPullRequest(projectId, request);
+    }
+
+    public void convertToDraft(String apiKey, PullRequestConvertedToDraftRequest request) {
+        Long projectId = projectApiKeyService.resolveProjectId(apiKey);
+        pullRequestConvertedToDraftService.convertToDraft(projectId, request);
+    }
+}

--- a/src/main/java/com/prism/statistics/application/collect/ProjectApiKeyService.java
+++ b/src/main/java/com/prism/statistics/application/collect/ProjectApiKeyService.java
@@ -1,0 +1,21 @@
+package com.prism.statistics.application.collect;
+
+import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
+import com.prism.statistics.domain.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectApiKeyService {
+
+    private final ProjectRepository projectRepository;
+
+    @Transactional(readOnly = true)
+    public Long resolveProjectId(String apiKey) {
+        return projectRepository.findIdByApiKey(apiKey)
+                .orElseThrow(() -> new InvalidApiKeyException());
+    }
+
+}

--- a/src/main/java/com/prism/statistics/application/collect/ProjectIdResolvingFacade.java
+++ b/src/main/java/com/prism/statistics/application/collect/ProjectIdResolvingFacade.java
@@ -11,11 +11,11 @@ import com.prism.statistics.application.analysis.metadata.pullrequest.dto.reques
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReadyForReviewRequest;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReopenedRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 @RequiredArgsConstructor
-public class CollectFacade {
+public class ProjectIdResolvingFacade {
 
     private final ProjectApiKeyService projectApiKeyService;
     private final PullRequestOpenedService pullRequestOpenedService;

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestClosedController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestClosedController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestClosedService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestClosedRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestClosedController {
 
-    private final PullRequestClosedService pullRequestClosedService;
+    private final CollectFacade collectFacade;
 
     @PostMapping("/closed")
     public ResponseEntity<Void> handlePullRequestClosed(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestClosedRequest request
     ) {
-        pullRequestClosedService.closePullRequest(apiKey, request);
+        collectFacade.closePullRequest(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestClosedController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestClosedController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestClosedRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestClosedController {
 
-    private final CollectFacade collectFacade;
+    private final ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @PostMapping("/closed")
     public ResponseEntity<Void> handlePullRequestClosed(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestClosedRequest request
     ) {
-        collectFacade.closePullRequest(apiKey, request);
+        projectIdResolvingFacade.closePullRequest(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestConvertedToDraftController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestConvertedToDraftController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestConvertedToDraftRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestConvertedToDraftController {
 
-    private final CollectFacade collectFacade;
+    private final ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @PostMapping("/converted-to-draft")
     public ResponseEntity<Void> handlePullRequestConvertedToDraft(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestConvertedToDraftRequest request
     ) {
-        collectFacade.convertToDraft(apiKey, request);
+        projectIdResolvingFacade.convertToDraft(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestConvertedToDraftController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestConvertedToDraftController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestConvertedToDraftService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestConvertedToDraftRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestConvertedToDraftController {
 
-    private final PullRequestConvertedToDraftService pullRequestConvertedToDraftService;
+    private final CollectFacade collectFacade;
 
     @PostMapping("/converted-to-draft")
     public ResponseEntity<Void> handlePullRequestConvertedToDraft(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestConvertedToDraftRequest request
     ) {
-        pullRequestConvertedToDraftService.convertToDraft(apiKey, request);
+        collectFacade.convertToDraft(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestOpenedController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestOpenedController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestOpenedController {
 
-    private final CollectFacade collectFacade;
+    private final ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @PostMapping("/opened")
     public ResponseEntity<Void> handlePullRequestOpened(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestOpenedRequest request
     ) {
-        collectFacade.createPullRequest(apiKey, request);
+        projectIdResolvingFacade.createPullRequest(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestOpenedController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestOpenedController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestOpenedService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestOpenedController {
 
-    private final PullRequestOpenedService pullRequestOpenedService;
+    private final CollectFacade collectFacade;
 
     @PostMapping("/opened")
     public ResponseEntity<Void> handlePullRequestOpened(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestOpenedRequest request
     ) {
-        pullRequestOpenedService.createPullRequest(apiKey, request);
+        collectFacade.createPullRequest(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReadyForReviewController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReadyForReviewController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestReadyForReviewService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReadyForReviewRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestReadyForReviewController {
 
-    private final PullRequestReadyForReviewService pullRequestReadyForReviewService;
+    private final CollectFacade collectFacade;
 
     @PostMapping("/ready-for-review")
     public ResponseEntity<Void> handlePullRequestReadyForReview(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestReadyForReviewRequest request
     ) {
-        pullRequestReadyForReviewService.readyForReview(apiKey, request);
+        collectFacade.readyForReview(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReadyForReviewController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReadyForReviewController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReadyForReviewRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestReadyForReviewController {
 
-    private final CollectFacade collectFacade;
+    private final ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @PostMapping("/ready-for-review")
     public ResponseEntity<Void> handlePullRequestReadyForReview(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestReadyForReviewRequest request
     ) {
-        collectFacade.readyForReview(apiKey, request);
+        projectIdResolvingFacade.readyForReview(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReopenedController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReopenedController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReopenedRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestReopenedController {
 
-    private final CollectFacade collectFacade;
+    private final ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @PostMapping("/reopened")
     public ResponseEntity<Void> handlePullRequestReopened(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestReopenedRequest request
     ) {
-        collectFacade.reopenPullRequest(apiKey, request);
+        projectIdResolvingFacade.reopenPullRequest(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReopenedController.java
+++ b/src/main/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReopenedController.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.presentation.collect.pullrequest;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestReopenedService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReopenedRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PullRequestReopenedController {
 
-    private final PullRequestReopenedService pullRequestReopenedService;
+    private final CollectFacade collectFacade;
 
     @PostMapping("/reopened")
     public ResponseEntity<Void> handlePullRequestReopened(
             @RequestHeader("X-API-Key") String apiKey,
             @RequestBody PullRequestReopenedRequest request
     ) {
-        pullRequestReopenedService.reopenPullRequest(apiKey, request);
+        collectFacade.reopenPullRequest(apiKey, request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestClosedServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestClosedServiceTest.java
@@ -1,7 +1,6 @@
 package com.prism.statistics.application.analysis.metadata.pullrequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.prism.statistics.application.IntegrationTest;
@@ -12,7 +11,6 @@ import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullReque
 import com.prism.statistics.domain.analysis.metadata.pullrequest.history.PullRequestStateHistory;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestRepository;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestStateHistoryRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -30,7 +28,7 @@ import java.time.LocalDateTime;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PullRequestClosedServiceTest {
 
-    private static final String TEST_API_KEY = "test-api-key";
+    private static final Long TEST_PROJECT_ID = 1L;
     private static final int TEST_PULL_REQUEST_NUMBER = 123;
     private static final String TEST_HEAD_COMMIT_SHA = "abc123";
     private static final Instant CLOSED_AT = Instant.parse("2099-01-15T12:00:00Z");
@@ -55,7 +53,7 @@ class PullRequestClosedServiceTest {
         PullRequestClosedRequest request = createClosedRequest();
 
         // when
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // then
         PullRequest pullRequest = jpaPullRequestRepository.findAll().getFirst();
@@ -69,7 +67,7 @@ class PullRequestClosedServiceTest {
         PullRequestClosedRequest request = createMergedRequest();
 
         // when
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // then
         PullRequest pullRequest = jpaPullRequestRepository.findAll().getFirst();
@@ -83,7 +81,7 @@ class PullRequestClosedServiceTest {
         PullRequestClosedRequest request = createClosedRequest();
 
         // when
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // then
         long eventCount = applicationEvents.stream(PullRequestStateChangedEvent.class).count();
@@ -97,7 +95,7 @@ class PullRequestClosedServiceTest {
         PullRequestClosedRequest request = createClosedRequest();
 
         // when
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // then
         assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(1);
@@ -116,7 +114,7 @@ class PullRequestClosedServiceTest {
         PullRequestClosedRequest request = createMergedRequest();
 
         // when
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // then
         assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(1);
@@ -135,7 +133,7 @@ class PullRequestClosedServiceTest {
         PullRequestClosedRequest request = createMergedRequest();
 
         // when
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // then
         PullRequestStateHistory history = jpaPullRequestStateHistoryRepository.findAll().getFirst();
@@ -148,10 +146,10 @@ class PullRequestClosedServiceTest {
     void 이미_닫힌_PullRequest에_대해_closed_이벤트가_오면_상태가_변경되지_않고_이벤트가_발행되지_않는다() {
         // given
         PullRequestClosedRequest request = createClosedRequest();
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // when
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // then
         long eventCount = applicationEvents.stream(PullRequestStateChangedEvent.class).count();
@@ -169,24 +167,13 @@ class PullRequestClosedServiceTest {
         PullRequestClosedRequest request = createClosedRequest();
 
         // when
-        pullRequestClosedService.closePullRequest(TEST_API_KEY, request);
+        pullRequestClosedService.closePullRequest(TEST_PROJECT_ID, request);
 
         // then
         assertAll(
                 () -> assertThat(applicationEvents.stream(PullRequestStateChangedEvent.class).count()).isEqualTo(0),
                 () -> assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(0)
         );
-    }
-
-    @Test
-    void 존재하지_않는_API_Key면_예외가_발생한다() {
-        // given
-        PullRequestClosedRequest request = createClosedRequest();
-        String invalidApiKey = "invalid-api-key";
-
-        // when & then
-        assertThatThrownBy(() -> pullRequestClosedService.closePullRequest(invalidApiKey, request))
-                .isInstanceOf(InvalidApiKeyException.class);
     }
 
     private PullRequestClosedRequest createClosedRequest() {

--- a/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestConvertedToDraftServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestConvertedToDraftServiceTest.java
@@ -1,7 +1,6 @@
 package com.prism.statistics.application.analysis.metadata.pullrequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.prism.statistics.application.IntegrationTest;
@@ -12,7 +11,6 @@ import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullReque
 import com.prism.statistics.domain.analysis.metadata.pullrequest.history.PullRequestStateHistory;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestRepository;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestStateHistoryRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -29,7 +27,7 @@ import java.time.Instant;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PullRequestConvertedToDraftServiceTest {
 
-    private static final String TEST_API_KEY = "test-api-key";
+    private static final Long TEST_PROJECT_ID = 1L;
     private static final int TEST_PULL_REQUEST_NUMBER = 123;
     private static final String TEST_HEAD_COMMIT_SHA = "abc123";
     private static final Instant CONVERTED_TO_DRAFT_AT = Instant.parse("2099-01-15T12:00:00Z");
@@ -53,7 +51,7 @@ class PullRequestConvertedToDraftServiceTest {
         PullRequestConvertedToDraftRequest request = createConvertedToDraftRequest();
 
         // when
-        pullRequestConvertedToDraftService.convertToDraft(TEST_API_KEY, request);
+        pullRequestConvertedToDraftService.convertToDraft(TEST_PROJECT_ID, request);
 
         // then
         PullRequest pullRequest = jpaPullRequestRepository.findAll().getFirst();
@@ -67,7 +65,7 @@ class PullRequestConvertedToDraftServiceTest {
         PullRequestConvertedToDraftRequest request = createConvertedToDraftRequest();
 
         // when
-        pullRequestConvertedToDraftService.convertToDraft(TEST_API_KEY, request);
+        pullRequestConvertedToDraftService.convertToDraft(TEST_PROJECT_ID, request);
 
         // then
         long eventCount = applicationEvents.stream(PullRequestStateChangedEvent.class).count();
@@ -81,7 +79,7 @@ class PullRequestConvertedToDraftServiceTest {
         PullRequestConvertedToDraftRequest request = createConvertedToDraftRequest();
 
         // when
-        pullRequestConvertedToDraftService.convertToDraft(TEST_API_KEY, request);
+        pullRequestConvertedToDraftService.convertToDraft(TEST_PROJECT_ID, request);
 
         // then
         assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(1);
@@ -100,7 +98,7 @@ class PullRequestConvertedToDraftServiceTest {
         PullRequestConvertedToDraftRequest request = createConvertedToDraftRequest();
 
         // when
-        pullRequestConvertedToDraftService.convertToDraft(TEST_API_KEY, request);
+        pullRequestConvertedToDraftService.convertToDraft(TEST_PROJECT_ID, request);
 
         // then
         assertAll(
@@ -117,24 +115,13 @@ class PullRequestConvertedToDraftServiceTest {
         PullRequestConvertedToDraftRequest request = createConvertedToDraftRequest();
 
         // when
-        pullRequestConvertedToDraftService.convertToDraft(TEST_API_KEY, request);
+        pullRequestConvertedToDraftService.convertToDraft(TEST_PROJECT_ID, request);
 
         // then
         assertAll(
                 () -> assertThat(applicationEvents.stream(PullRequestStateChangedEvent.class).count()).isEqualTo(0),
                 () -> assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(0)
         );
-    }
-
-    @Test
-    void 존재하지_않는_API_Key면_예외가_발생한다() {
-        // given
-        PullRequestConvertedToDraftRequest request = createConvertedToDraftRequest();
-        String invalidApiKey = "invalid-api-key";
-
-        // when & then
-        assertThatThrownBy(() -> pullRequestConvertedToDraftService.convertToDraft(invalidApiKey, request))
-                .isInstanceOf(InvalidApiKeyException.class);
     }
 
     private PullRequestConvertedToDraftRequest createConvertedToDraftRequest() {

--- a/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestOpenedServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestOpenedServiceTest.java
@@ -1,7 +1,6 @@
 package com.prism.statistics.application.analysis.metadata.pullrequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.prism.statistics.application.IntegrationTest;
@@ -21,7 +20,6 @@ import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persist
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestFileRepository;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestStateHistoryRepository;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -39,7 +37,7 @@ import java.util.List;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PullRequestOpenedServiceTest {
 
-    private static final String TEST_API_KEY = "test-api-key";
+    private static final Long TEST_PROJECT_ID = 1L;
 
     @Autowired
     private PullRequestOpenedService pullRequestOpenedService;
@@ -72,7 +70,7 @@ class PullRequestOpenedServiceTest {
         PullRequestOpenedRequest request = createPullRequestOpenedRequest(false);
 
         // when
-        pullRequestOpenedService.createPullRequest(TEST_API_KEY, request);
+        pullRequestOpenedService.createPullRequest(TEST_PROJECT_ID, request);
 
         // then
         assertAll(
@@ -92,7 +90,7 @@ class PullRequestOpenedServiceTest {
         PullRequestOpenedRequest request = createPullRequestOpenedRequest(false);
 
         // when
-        pullRequestOpenedService.createPullRequest(TEST_API_KEY, request);
+        pullRequestOpenedService.createPullRequest(TEST_PROJECT_ID, request);
 
         // then
         PullRequest pullRequest = jpaPullRequestRepository.findAll().getFirst();
@@ -106,7 +104,7 @@ class PullRequestOpenedServiceTest {
         PullRequestOpenedRequest request = createPullRequestOpenedRequest(true);
 
         // when
-        pullRequestOpenedService.createPullRequest(TEST_API_KEY, request);
+        pullRequestOpenedService.createPullRequest(TEST_PROJECT_ID, request);
 
         // then
         PullRequest pullRequest = jpaPullRequestRepository.findAll().getFirst();
@@ -120,7 +118,7 @@ class PullRequestOpenedServiceTest {
         PullRequestOpenedRequest request = createPullRequestOpenedRequest(false);
 
         // when
-        pullRequestOpenedService.createPullRequest(TEST_API_KEY, request);
+        pullRequestOpenedService.createPullRequest(TEST_PROJECT_ID, request);
 
         // then
         long eventCount = applicationEvents.stream(PullRequestOpenCreatedEvent.class).count();
@@ -134,7 +132,7 @@ class PullRequestOpenedServiceTest {
         PullRequestOpenedRequest request = createPullRequestOpenedRequest(true);
 
         // when
-        pullRequestOpenedService.createPullRequest(TEST_API_KEY, request);
+        pullRequestOpenedService.createPullRequest(TEST_PROJECT_ID, request);
 
         // then
         long eventCount = applicationEvents.stream(PullRequestOpenCreatedEvent.class).count();
@@ -147,18 +145,6 @@ class PullRequestOpenedServiceTest {
                 () -> assertThat(jpaPullRequestContentHistoryRepository.count()).isEqualTo(1),
                 () -> assertThat(jpaPullRequestFileHistoryRepository.count()).isEqualTo(2)
         );
-    }
-
-    @Test
-    void 존재하지_않는_API_Key면_예외가_발생한다() {
-        // given
-        PullRequestOpenedRequest request = createPullRequestOpenedRequest(false);
-        String invalidApiKey = "invalid-api-key";
-
-        // when & then
-        assertThatThrownBy(() -> pullRequestOpenedService.createPullRequest(invalidApiKey, request))
-                .isInstanceOf(InvalidApiKeyException.class)
-                .hasMessage("유효하지 않은 API Key입니다.");
     }
 
     private PullRequestOpenedRequest createPullRequestOpenedRequest(boolean isDraft) {

--- a/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestReadyForReviewServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestReadyForReviewServiceTest.java
@@ -1,7 +1,6 @@
 package com.prism.statistics.application.analysis.metadata.pullrequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.prism.statistics.application.IntegrationTest;
@@ -12,7 +11,6 @@ import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullReque
 import com.prism.statistics.domain.analysis.metadata.pullrequest.history.PullRequestStateHistory;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestRepository;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestStateHistoryRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -29,7 +27,7 @@ import java.time.Instant;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PullRequestReadyForReviewServiceTest {
 
-    private static final String TEST_API_KEY = "test-api-key";
+    private static final Long TEST_PROJECT_ID = 1L;
     private static final int TEST_PULL_REQUEST_NUMBER = 123;
     private static final String TEST_HEAD_COMMIT_SHA = "abc123";
     private static final Instant READY_FOR_REVIEW_AT = Instant.parse("2099-01-15T12:00:00Z");
@@ -53,7 +51,7 @@ class PullRequestReadyForReviewServiceTest {
         PullRequestReadyForReviewRequest request = createReadyForReviewRequest();
 
         // when
-        pullRequestReadyForReviewService.readyForReview(TEST_API_KEY, request);
+        pullRequestReadyForReviewService.readyForReview(TEST_PROJECT_ID, request);
 
         // then
         PullRequest pullRequest = jpaPullRequestRepository.findAll().getFirst();
@@ -67,7 +65,7 @@ class PullRequestReadyForReviewServiceTest {
         PullRequestReadyForReviewRequest request = createReadyForReviewRequest();
 
         // when
-        pullRequestReadyForReviewService.readyForReview(TEST_API_KEY, request);
+        pullRequestReadyForReviewService.readyForReview(TEST_PROJECT_ID, request);
 
         // then
         long eventCount = applicationEvents.stream(PullRequestStateChangedEvent.class).count();
@@ -81,7 +79,7 @@ class PullRequestReadyForReviewServiceTest {
         PullRequestReadyForReviewRequest request = createReadyForReviewRequest();
 
         // when
-        pullRequestReadyForReviewService.readyForReview(TEST_API_KEY, request);
+        pullRequestReadyForReviewService.readyForReview(TEST_PROJECT_ID, request);
 
         // then
         assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(1);
@@ -100,7 +98,7 @@ class PullRequestReadyForReviewServiceTest {
         PullRequestReadyForReviewRequest request = createReadyForReviewRequest();
 
         // when
-        pullRequestReadyForReviewService.readyForReview(TEST_API_KEY, request);
+        pullRequestReadyForReviewService.readyForReview(TEST_PROJECT_ID, request);
 
         // then
         assertAll(
@@ -117,24 +115,13 @@ class PullRequestReadyForReviewServiceTest {
         PullRequestReadyForReviewRequest request = createReadyForReviewRequest();
 
         // when
-        pullRequestReadyForReviewService.readyForReview(TEST_API_KEY, request);
+        pullRequestReadyForReviewService.readyForReview(TEST_PROJECT_ID, request);
 
         // then
         assertAll(
                 () -> assertThat(applicationEvents.stream(PullRequestStateChangedEvent.class).count()).isEqualTo(0),
                 () -> assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(0)
         );
-    }
-
-    @Test
-    void 존재하지_않는_API_Key면_예외가_발생한다() {
-        // given
-        PullRequestReadyForReviewRequest request = createReadyForReviewRequest();
-        String invalidApiKey = "invalid-api-key";
-
-        // when & then
-        assertThatThrownBy(() -> pullRequestReadyForReviewService.readyForReview(invalidApiKey, request))
-                .isInstanceOf(InvalidApiKeyException.class);
     }
 
     private PullRequestReadyForReviewRequest createReadyForReviewRequest() {

--- a/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestReopenedServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/analysis/metadata/pullrequest/PullRequestReopenedServiceTest.java
@@ -1,7 +1,6 @@
 package com.prism.statistics.application.analysis.metadata.pullrequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.prism.statistics.application.IntegrationTest;
@@ -12,7 +11,6 @@ import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullReque
 import com.prism.statistics.domain.analysis.metadata.pullrequest.history.PullRequestStateHistory;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestRepository;
 import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestStateHistoryRepository;
-import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -29,7 +27,7 @@ import java.time.Instant;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PullRequestReopenedServiceTest {
 
-    private static final String TEST_API_KEY = "test-api-key";
+    private static final Long TEST_PROJECT_ID = 1L;
     private static final int TEST_PULL_REQUEST_NUMBER = 123;
     private static final String TEST_HEAD_COMMIT_SHA = "abc123";
     private static final Instant REOPENED_AT = Instant.parse("2099-01-15T12:00:00Z");
@@ -53,7 +51,7 @@ class PullRequestReopenedServiceTest {
         PullRequestReopenedRequest request = createReopenedRequest();
 
         // when
-        pullRequestReopenedService.reopenPullRequest(TEST_API_KEY, request);
+        pullRequestReopenedService.reopenPullRequest(TEST_PROJECT_ID, request);
 
         // then
         PullRequest pullRequest = jpaPullRequestRepository.findAll().getFirst();
@@ -67,7 +65,7 @@ class PullRequestReopenedServiceTest {
         PullRequestReopenedRequest request = createReopenedRequest();
 
         // when
-        pullRequestReopenedService.reopenPullRequest(TEST_API_KEY, request);
+        pullRequestReopenedService.reopenPullRequest(TEST_PROJECT_ID, request);
 
         // then
         long eventCount = applicationEvents.stream(PullRequestStateChangedEvent.class).count();
@@ -81,7 +79,7 @@ class PullRequestReopenedServiceTest {
         PullRequestReopenedRequest request = createReopenedRequest();
 
         // when
-        pullRequestReopenedService.reopenPullRequest(TEST_API_KEY, request);
+        pullRequestReopenedService.reopenPullRequest(TEST_PROJECT_ID, request);
 
         // then
         assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(1);
@@ -100,7 +98,7 @@ class PullRequestReopenedServiceTest {
         PullRequestReopenedRequest request = createReopenedRequest();
 
         // when
-        pullRequestReopenedService.reopenPullRequest(TEST_API_KEY, request);
+        pullRequestReopenedService.reopenPullRequest(TEST_PROJECT_ID, request);
 
         // then
         PullRequest pullRequest = jpaPullRequestRepository.findAll().getFirst();
@@ -114,7 +112,7 @@ class PullRequestReopenedServiceTest {
         PullRequestReopenedRequest request = createReopenedRequest();
 
         // when
-        pullRequestReopenedService.reopenPullRequest(TEST_API_KEY, request);
+        pullRequestReopenedService.reopenPullRequest(TEST_PROJECT_ID, request);
 
         // then
         assertAll(
@@ -131,24 +129,13 @@ class PullRequestReopenedServiceTest {
         PullRequestReopenedRequest request = createReopenedRequest();
 
         // when
-        pullRequestReopenedService.reopenPullRequest(TEST_API_KEY, request);
+        pullRequestReopenedService.reopenPullRequest(TEST_PROJECT_ID, request);
 
         // then
         assertAll(
                 () -> assertThat(applicationEvents.stream(PullRequestStateChangedEvent.class).count()).isEqualTo(0),
                 () -> assertThat(jpaPullRequestStateHistoryRepository.count()).isEqualTo(0)
         );
-    }
-
-    @Test
-    void 존재하지_않는_API_Key면_예외가_발생한다() {
-        // given
-        PullRequestReopenedRequest request = createReopenedRequest();
-        String invalidApiKey = "invalid-api-key";
-
-        // when & then
-        assertThatThrownBy(() -> pullRequestReopenedService.reopenPullRequest(invalidApiKey, request))
-                .isInstanceOf(InvalidApiKeyException.class);
     }
 
     private PullRequestReopenedRequest createReopenedRequest() {

--- a/src/test/java/com/prism/statistics/application/collect/CollectFacadeTest.java
+++ b/src/test/java/com/prism/statistics/application/collect/CollectFacadeTest.java
@@ -1,0 +1,158 @@
+package com.prism.statistics.application.collect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.prism.statistics.application.IntegrationTest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestClosedRequest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestConvertedToDraftRequest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest.Author;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest.CommitData;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest.CommitNode;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest.CommitsConnection;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest.FileData;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest.PullRequestData;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReadyForReviewRequest;
+import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReopenedRequest;
+import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
+import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
+import com.prism.statistics.infrastructure.analysis.metadata.pullrequest.persistence.JpaPullRequestRepository;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@IntegrationTest
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CollectFacadeTest {
+
+    private static final String TEST_API_KEY = "test-api-key";
+
+    @Autowired
+    private CollectFacade collectFacade;
+
+    @Autowired
+    private JpaPullRequestRepository jpaPullRequestRepository;
+
+    @Sql("/sql/webhook/insert_project.sql")
+    @Test
+    void apiKey를_projectId로_변환하여_PullRequest를_생성한다() {
+        // given
+        PullRequestOpenedRequest request = createPullRequestOpenedRequest();
+
+        // when
+        collectFacade.createPullRequest(TEST_API_KEY, request);
+
+        // then
+        assertThat(jpaPullRequestRepository.count()).isEqualTo(1);
+    }
+
+    @Sql("/sql/webhook/insert_project_and_pull_request.sql")
+    @Test
+    void apiKey를_projectId로_변환하여_PullRequest를_닫는다() {
+        // given
+        PullRequestClosedRequest request = new PullRequestClosedRequest(
+                123, false, Instant.now(), null
+        );
+
+        // when
+        collectFacade.closePullRequest(TEST_API_KEY, request);
+
+        // then
+        assertThat(jpaPullRequestRepository.findAll().getFirst().getState())
+                .isEqualTo(PullRequestState.CLOSED);
+    }
+
+    @Sql("/sql/webhook/insert_project_and_draft_pull_request.sql")
+    @Test
+    void apiKey를_projectId로_변환하여_PullRequest를_리뷰_준비_상태로_변경한다() {
+        // given
+        PullRequestReadyForReviewRequest request = new PullRequestReadyForReviewRequest(
+                123, Instant.now()
+        );
+
+        // when
+        collectFacade.readyForReview(TEST_API_KEY, request);
+
+        // then
+        assertThat(jpaPullRequestRepository.findAll().getFirst().getState())
+                .isEqualTo(PullRequestState.OPEN);
+    }
+
+    @Sql("/sql/webhook/insert_project_and_closed_pull_request.sql")
+    @Test
+    void apiKey를_projectId로_변환하여_PullRequest를_다시_연다() {
+        // given
+        PullRequestReopenedRequest request = new PullRequestReopenedRequest(
+                123, Instant.now()
+        );
+
+        // when
+        collectFacade.reopenPullRequest(TEST_API_KEY, request);
+
+        // then
+        assertThat(jpaPullRequestRepository.findAll().getFirst().getState())
+                .isEqualTo(PullRequestState.OPEN);
+    }
+
+    @Sql("/sql/webhook/insert_project_and_pull_request.sql")
+    @Test
+    void apiKey를_projectId로_변환하여_PullRequest를_Draft로_변환한다() {
+        // given
+        PullRequestConvertedToDraftRequest request = new PullRequestConvertedToDraftRequest(
+                123, Instant.now()
+        );
+
+        // when
+        collectFacade.convertToDraft(TEST_API_KEY, request);
+
+        // then
+        assertThat(jpaPullRequestRepository.findAll().getFirst().getState())
+                .isEqualTo(PullRequestState.DRAFT);
+    }
+
+    @Test
+    void 잘못된_apiKey로_호출하면_예외가_발생한다() {
+        // given
+        PullRequestClosedRequest request = new PullRequestClosedRequest(
+                123, false, Instant.now(), null
+        );
+
+        // when & then
+        assertThatThrownBy(() -> collectFacade.closePullRequest("invalid-api-key", request))
+                .isInstanceOf(InvalidApiKeyException.class);
+    }
+
+    private PullRequestOpenedRequest createPullRequestOpenedRequest() {
+        List<CommitNode> commitNodes = List.of(
+                new CommitNode(new CommitData("abc123", Instant.parse("2024-01-15T09:00:00Z"))),
+                new CommitNode(new CommitData("def456", Instant.parse("2024-01-15T09:30:00Z")))
+        );
+
+        PullRequestData pullRequestData = new PullRequestData(
+                100L,
+                42,
+                "테스트 PR 제목",
+                "https://github.com/owner/repo/pull/42",
+                "abc123",
+                100,
+                50,
+                10,
+                Instant.parse("2024-01-15T10:00:00Z"),
+                new Author("test-author", 1L),
+                new CommitsConnection(2, commitNodes)
+        );
+
+        List<FileData> files = List.of(
+                new FileData("src/main/java/Example.java", "modified", 80, 30),
+                new FileData("src/main/java/NewFile.java", "added", 20, 0)
+        );
+
+        return new PullRequestOpenedRequest(false, pullRequestData, files);
+    }
+}

--- a/src/test/java/com/prism/statistics/application/collect/ProjectApiKeyServiceTest.java
+++ b/src/test/java/com/prism/statistics/application/collect/ProjectApiKeyServiceTest.java
@@ -1,0 +1,44 @@
+package com.prism.statistics.application.collect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.prism.statistics.application.IntegrationTest;
+import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@IntegrationTest
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ProjectApiKeyServiceTest {
+
+    private static final String TEST_API_KEY = "test-api-key";
+
+    @Autowired
+    private ProjectApiKeyService projectApiKeyService;
+
+    @Sql("/sql/webhook/insert_project.sql")
+    @Test
+    void 유효한_API_Key로_프로젝트_ID를_조회한다() {
+        // when
+        Long projectId = projectApiKeyService.resolveProjectId(TEST_API_KEY);
+
+        // then
+        assertThat(projectId).isEqualTo(1L);
+    }
+
+    @Test
+    void 존재하지_않는_API_Key로_프로젝트_ID를_조회하면_예외가_발생한다() {
+        // given
+        String invalidApiKey = "invalid-api-key";
+
+        // when & then
+        assertThatThrownBy(() -> projectApiKeyService.resolveProjectId(invalidApiKey))
+                .isInstanceOf(InvalidApiKeyException.class);
+    }
+
+}

--- a/src/test/java/com/prism/statistics/application/collect/ProjectIdResolvingFacadeTest.java
+++ b/src/test/java/com/prism/statistics/application/collect/ProjectIdResolvingFacadeTest.java
@@ -29,12 +29,12 @@ import org.springframework.test.context.jdbc.Sql;
 @IntegrationTest
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class CollectFacadeTest {
+class ProjectIdResolvingFacadeTest {
 
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private CollectFacade collectFacade;
+    private ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @Autowired
     private JpaPullRequestRepository jpaPullRequestRepository;
@@ -46,7 +46,7 @@ class CollectFacadeTest {
         PullRequestOpenedRequest request = createPullRequestOpenedRequest();
 
         // when
-        collectFacade.createPullRequest(TEST_API_KEY, request);
+        projectIdResolvingFacade.createPullRequest(TEST_API_KEY, request);
 
         // then
         assertThat(jpaPullRequestRepository.count()).isEqualTo(1);
@@ -61,7 +61,7 @@ class CollectFacadeTest {
         );
 
         // when
-        collectFacade.closePullRequest(TEST_API_KEY, request);
+        projectIdResolvingFacade.closePullRequest(TEST_API_KEY, request);
 
         // then
         assertThat(jpaPullRequestRepository.findAll().getFirst().getState())
@@ -77,7 +77,7 @@ class CollectFacadeTest {
         );
 
         // when
-        collectFacade.readyForReview(TEST_API_KEY, request);
+        projectIdResolvingFacade.readyForReview(TEST_API_KEY, request);
 
         // then
         assertThat(jpaPullRequestRepository.findAll().getFirst().getState())
@@ -93,7 +93,7 @@ class CollectFacadeTest {
         );
 
         // when
-        collectFacade.reopenPullRequest(TEST_API_KEY, request);
+        projectIdResolvingFacade.reopenPullRequest(TEST_API_KEY, request);
 
         // then
         assertThat(jpaPullRequestRepository.findAll().getFirst().getState())
@@ -109,7 +109,7 @@ class CollectFacadeTest {
         );
 
         // when
-        collectFacade.convertToDraft(TEST_API_KEY, request);
+        projectIdResolvingFacade.convertToDraft(TEST_API_KEY, request);
 
         // then
         assertThat(jpaPullRequestRepository.findAll().getFirst().getState())
@@ -124,7 +124,7 @@ class CollectFacadeTest {
         );
 
         // when & then
-        assertThatThrownBy(() -> collectFacade.closePullRequest("invalid-api-key", request))
+        assertThatThrownBy(() -> projectIdResolvingFacade.closePullRequest("invalid-api-key", request))
                 .isInstanceOf(InvalidApiKeyException.class);
     }
 

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestClosedControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestClosedControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestClosedService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestClosedRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private PullRequestClosedService pullRequestClosedService;
+    private CollectFacade collectFacade;
 
     @Test
     void Pull_Request_closed_웹훅_요청을_처리한다() throws Exception {
@@ -38,7 +38,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 }
                 """;
 
-        willDoNothing().given(pullRequestClosedService).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+        willDoNothing().given(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -49,7 +49,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 )
                 .andExpect(status().isOk());
 
-        verify(pullRequestClosedService).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+        verify(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
     }
 
     @Test
@@ -65,7 +65,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 }
                 """;
 
-        willDoNothing().given(pullRequestClosedService).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+        willDoNothing().given(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -76,7 +76,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 )
                 .andExpect(status().isOk());
 
-        verify(pullRequestClosedService).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+        verify(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
     }
 
     @Test
@@ -103,7 +103,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(pullRequestClosedService).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+                .given(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestClosedControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestClosedControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestClosedRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private CollectFacade collectFacade;
+    private ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @Test
     void Pull_Request_closed_웹훅_요청을_처리한다() throws Exception {
@@ -38,7 +38,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 }
                 """;
 
-        willDoNothing().given(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+        willDoNothing().given(projectIdResolvingFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -49,7 +49,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 )
                 .andExpect(status().isOk());
 
-        verify(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+        verify(projectIdResolvingFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
     }
 
     @Test
@@ -65,7 +65,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 }
                 """;
 
-        willDoNothing().given(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+        willDoNothing().given(projectIdResolvingFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -76,7 +76,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 )
                 .andExpect(status().isOk());
 
-        verify(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+        verify(projectIdResolvingFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
     }
 
     @Test
@@ -103,7 +103,7 @@ class PullRequestClosedControllerTest extends CommonControllerSliceTestSupport {
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(collectFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
+                .given(projectIdResolvingFacade).closePullRequest(eq(TEST_API_KEY), any(PullRequestClosedRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestConvertedToDraftControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestConvertedToDraftControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestConvertedToDraftRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestConvertedToDraftControllerTest extends CommonControllerSliceTes
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private CollectFacade collectFacade;
+    private ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @Test
     void Pull_Request_converted_to_draft_웹훅_요청을_처리한다() throws Exception {
@@ -36,7 +36,7 @@ class PullRequestConvertedToDraftControllerTest extends CommonControllerSliceTes
                 }
                 """;
 
-        willDoNothing().given(collectFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
+        willDoNothing().given(projectIdResolvingFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -47,7 +47,7 @@ class PullRequestConvertedToDraftControllerTest extends CommonControllerSliceTes
                 )
                 .andExpect(status().isOk());
 
-        verify(collectFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
+        verify(projectIdResolvingFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
     }
 
     @Test
@@ -72,7 +72,7 @@ class PullRequestConvertedToDraftControllerTest extends CommonControllerSliceTes
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(collectFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
+                .given(projectIdResolvingFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestConvertedToDraftControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestConvertedToDraftControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestConvertedToDraftService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestConvertedToDraftRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestConvertedToDraftControllerTest extends CommonControllerSliceTes
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private PullRequestConvertedToDraftService pullRequestConvertedToDraftService;
+    private CollectFacade collectFacade;
 
     @Test
     void Pull_Request_converted_to_draft_웹훅_요청을_처리한다() throws Exception {
@@ -36,7 +36,7 @@ class PullRequestConvertedToDraftControllerTest extends CommonControllerSliceTes
                 }
                 """;
 
-        willDoNothing().given(pullRequestConvertedToDraftService).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
+        willDoNothing().given(collectFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -47,7 +47,7 @@ class PullRequestConvertedToDraftControllerTest extends CommonControllerSliceTes
                 )
                 .andExpect(status().isOk());
 
-        verify(pullRequestConvertedToDraftService).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
+        verify(collectFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
     }
 
     @Test
@@ -72,7 +72,7 @@ class PullRequestConvertedToDraftControllerTest extends CommonControllerSliceTes
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(pullRequestConvertedToDraftService).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
+                .given(collectFacade).convertToDraft(eq(TEST_API_KEY), any(PullRequestConvertedToDraftRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestOpenedControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestOpenedControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestOpenedService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestOpenedControllerTest extends CommonControllerSliceTestSupport {
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private PullRequestOpenedService pullRequestOpenedService;
+    private CollectFacade collectFacade;
 
     @Test
     void Pull_Request_opened_웹훅_요청을_처리한다() throws Exception {
@@ -56,7 +56,7 @@ class PullRequestOpenedControllerTest extends CommonControllerSliceTestSupport {
                 }
                 """;
 
-        willDoNothing().given(pullRequestOpenedService).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
+        willDoNothing().given(collectFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -67,7 +67,7 @@ class PullRequestOpenedControllerTest extends CommonControllerSliceTestSupport {
                 )
                 .andExpect(status().isOk());
 
-        verify(pullRequestOpenedService).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
+        verify(collectFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
     }
 
     @Test
@@ -112,7 +112,7 @@ class PullRequestOpenedControllerTest extends CommonControllerSliceTestSupport {
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(pullRequestOpenedService).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
+                .given(collectFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestOpenedControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestOpenedControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestOpenedRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestOpenedControllerTest extends CommonControllerSliceTestSupport {
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private CollectFacade collectFacade;
+    private ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @Test
     void Pull_Request_opened_웹훅_요청을_처리한다() throws Exception {
@@ -56,7 +56,7 @@ class PullRequestOpenedControllerTest extends CommonControllerSliceTestSupport {
                 }
                 """;
 
-        willDoNothing().given(collectFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
+        willDoNothing().given(projectIdResolvingFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -67,7 +67,7 @@ class PullRequestOpenedControllerTest extends CommonControllerSliceTestSupport {
                 )
                 .andExpect(status().isOk());
 
-        verify(collectFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
+        verify(projectIdResolvingFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
     }
 
     @Test
@@ -112,7 +112,7 @@ class PullRequestOpenedControllerTest extends CommonControllerSliceTestSupport {
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(collectFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
+                .given(projectIdResolvingFacade).createPullRequest(eq(TEST_API_KEY), any(PullRequestOpenedRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReadyForReviewControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReadyForReviewControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestReadyForReviewService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReadyForReviewRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestReadyForReviewControllerTest extends CommonControllerSliceTestS
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private PullRequestReadyForReviewService pullRequestReadyForReviewService;
+    private CollectFacade collectFacade;
 
     @Test
     void Pull_Request_ready_for_review_웹훅_요청을_처리한다() throws Exception {
@@ -36,7 +36,7 @@ class PullRequestReadyForReviewControllerTest extends CommonControllerSliceTestS
                 }
                 """;
 
-        willDoNothing().given(pullRequestReadyForReviewService).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
+        willDoNothing().given(collectFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -47,7 +47,7 @@ class PullRequestReadyForReviewControllerTest extends CommonControllerSliceTestS
                 )
                 .andExpect(status().isOk());
 
-        verify(pullRequestReadyForReviewService).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
+        verify(collectFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
     }
 
     @Test
@@ -72,7 +72,7 @@ class PullRequestReadyForReviewControllerTest extends CommonControllerSliceTestS
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(pullRequestReadyForReviewService).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
+                .given(collectFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReadyForReviewControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReadyForReviewControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReadyForReviewRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestReadyForReviewControllerTest extends CommonControllerSliceTestS
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private CollectFacade collectFacade;
+    private ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @Test
     void Pull_Request_ready_for_review_웹훅_요청을_처리한다() throws Exception {
@@ -36,7 +36,7 @@ class PullRequestReadyForReviewControllerTest extends CommonControllerSliceTestS
                 }
                 """;
 
-        willDoNothing().given(collectFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
+        willDoNothing().given(projectIdResolvingFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -47,7 +47,7 @@ class PullRequestReadyForReviewControllerTest extends CommonControllerSliceTestS
                 )
                 .andExpect(status().isOk());
 
-        verify(collectFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
+        verify(projectIdResolvingFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
     }
 
     @Test
@@ -72,7 +72,7 @@ class PullRequestReadyForReviewControllerTest extends CommonControllerSliceTestS
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(collectFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
+                .given(projectIdResolvingFacade).readyForReview(eq(TEST_API_KEY), any(PullRequestReadyForReviewRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReopenedControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReopenedControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.analysis.metadata.pullrequest.PullRequestReopenedService;
+import com.prism.statistics.application.collect.CollectFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReopenedRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestReopenedControllerTest extends CommonControllerSliceTestSupport
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private PullRequestReopenedService pullRequestReopenedService;
+    private CollectFacade collectFacade;
 
     @Test
     void Pull_Request_reopened_웹훅_요청을_처리한다() throws Exception {
@@ -36,7 +36,7 @@ class PullRequestReopenedControllerTest extends CommonControllerSliceTestSupport
                 }
                 """;
 
-        willDoNothing().given(pullRequestReopenedService).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
+        willDoNothing().given(collectFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -47,7 +47,7 @@ class PullRequestReopenedControllerTest extends CommonControllerSliceTestSupport
                 )
                 .andExpect(status().isOk());
 
-        verify(pullRequestReopenedService).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
+        verify(collectFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
     }
 
     @Test
@@ -72,7 +72,7 @@ class PullRequestReopenedControllerTest extends CommonControllerSliceTestSupport
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(pullRequestReopenedService).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
+                .given(collectFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
 
         // when & then
         mockMvc.perform(

--- a/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReopenedControllerTest.java
+++ b/src/test/java/com/prism/statistics/presentation/collect/pullrequest/PullRequestReopenedControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.prism.statistics.application.collect.CollectFacade;
+import com.prism.statistics.application.collect.ProjectIdResolvingFacade;
 import com.prism.statistics.application.analysis.metadata.pullrequest.dto.request.PullRequestReopenedRequest;
 import com.prism.statistics.domain.project.exception.InvalidApiKeyException;
 import com.prism.statistics.presentation.CommonControllerSliceTestSupport;
@@ -24,7 +24,7 @@ class PullRequestReopenedControllerTest extends CommonControllerSliceTestSupport
     private static final String TEST_API_KEY = "test-api-key";
 
     @Autowired
-    private CollectFacade collectFacade;
+    private ProjectIdResolvingFacade projectIdResolvingFacade;
 
     @Test
     void Pull_Request_reopened_웹훅_요청을_처리한다() throws Exception {
@@ -36,7 +36,7 @@ class PullRequestReopenedControllerTest extends CommonControllerSliceTestSupport
                 }
                 """;
 
-        willDoNothing().given(collectFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
+        willDoNothing().given(projectIdResolvingFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
 
         // when & then
         mockMvc.perform(
@@ -47,7 +47,7 @@ class PullRequestReopenedControllerTest extends CommonControllerSliceTestSupport
                 )
                 .andExpect(status().isOk());
 
-        verify(collectFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
+        verify(projectIdResolvingFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
     }
 
     @Test
@@ -72,7 +72,7 @@ class PullRequestReopenedControllerTest extends CommonControllerSliceTestSupport
                 """;
 
         willThrow(new InvalidApiKeyException())
-                .given(collectFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
+                .given(projectIdResolvingFacade).reopenPullRequest(eq(TEST_API_KEY), any(PullRequestReopenedRequest.class));
 
         // when & then
         mockMvc.perform(


### PR DESCRIPTION
 # 관련 이슈 번호
  - closed #134

  ## 이 PR을 통해 해결하려는 문제가 무엇인가요?

  기존에는 5개의 PullRequest 상태 변경 서비스(Opened, Closed, Reopened, ReadyForReview, ConvertedToDraft)가 각각 `ProjectRepository`에 직접 의존하여 apiKey → projectId 변환을 수행하고 있었습니다.

  - apiKey 변환 로직이 5개 서비스에 중복 존재
  - 서비스가 apiKey를 알아야 할 이유가 없음 (비즈니스 로직에는 projectId만 필요)
  - 향후 Inbox 패턴 도입 시 AOP가 서비스 메서드의 projectId를 캡처해야 하므로, 시그니처 정리가 선행되어야 함

  ## 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

  - **ProjectApiKeyService 추가**: apiKey → projectId 변환 책임을 단일 서비스로 추출
  - **CollectFacade 추가**: ProjectApiKeyService로 projectId를 얻고, 해당 서비스를 호출하는 조합 계층
  - **서비스 시그니처 변경**: 5개 서비스의 파라미터를 `(String apiKey, Request)` → `(Long projectId, Request)`로 변경하고, 내부 `findIdByApiKey` 호출 제거
  - **Controller 의존성 변경**: 5개 Controller가 개별 서비스 대신 CollectFacade를 경유하도록 변경

  ## 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

  - 서비스 테스트 5개: `TEST_API_KEY` → `TEST_PROJECT_ID`로 변경, 불필요한 apiKey 예외 테스트 제거
  - Controller 테스트 5개: 개별 서비스 mock → CollectFacade mock으로 변경
  - CollectFacadeTest, ProjectApiKeyServiceTest 통합 테스트 추가

  ## Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

  - **CollectFacade의 의존성 범위**: 현재 projectId가 필요한 5개 서비스만 의존합니다. 나머지 9개 서비스(Label, Review, Reviewer 등)는 projectId를 비즈니스 로직에 사용하지 않으므로 Facade에 포함하지 않았는데, 이 구분이 적절한지 의견 부탁드립니다.
  - **추상화 수준**: Controller → CollectFacade → Service 흐름에서 Facade가 "apiKey 변환 + 서비스 위임"만 담당하는 얇은 계층인데, 이 정도의 추상화가 적절한지 혹은 과한지 의견 부탁드립니다.
  - 향후 Inbox 패턴 도입 시 서비스 레벨에 `@InboxEnqueue` AOP를 적용할 예정인데, 현재 시그니처 변경이 그 방향과 잘 맞는지도 확인 부탁드립니다.
