### PR TITLE
GitHub OAuth 로그인 기능

### DIFF
--- a/src/main/java/com/prism/statistics/domain/user/enums/RegistrationId.java
+++ b/src/main/java/com/prism/statistics/domain/user/enums/RegistrationId.java
@@ -5,7 +5,8 @@ import java.util.Arrays;
 public enum RegistrationId {
 
     KAKAO("kakao"),
-    GOOGLE("google");
+    GOOGLE("google"),
+    GITHUB("github");
 
     private final String name;
 

--- a/src/main/java/com/prism/statistics/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/prism/statistics/global/security/handler/OAuth2SuccessHandler.java
@@ -28,7 +28,6 @@ import org.springframework.security.authentication.AuthenticationServiceExceptio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -76,16 +75,11 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private String extractSocialId(Authentication authentication) {
         Object principal = authentication.getPrincipal();
 
-        if (principal instanceof OidcUser oidcUser) {
-            return oidcUser.getSubject();
+        if (!(principal instanceof OAuth2User oAuth2User)) {
+            throw new AuthenticationServiceException("소셜 로그인 사용자 정보가 없습니다.");
         }
 
-        if (principal instanceof OAuth2User oAuth2User) {
-            int id = oAuth2User.getAttribute("id");
-            return String.valueOf(id);
-        }
-
-        throw new AuthenticationServiceException("소셜 로그인 사용자 정보가 없습니다.");
+        return oAuth2User.getName();
     }
 
     private TokenResponse generateTokens(Long userId) {

--- a/src/main/java/com/prism/statistics/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/prism/statistics/global/security/handler/OAuth2SuccessHandler.java
@@ -81,7 +81,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         }
 
         if (principal instanceof OAuth2User oAuth2User) {
-            return String.valueOf(oAuth2User.getAttribute("id"));
+            int id = oAuth2User.getAttribute("id");
+            return String.valueOf(id);
         }
 
         throw new AuthenticationServiceException("소셜 로그인 사용자 정보가 없습니다.");

--- a/src/main/java/com/prism/statistics/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/prism/statistics/global/security/handler/OAuth2SuccessHandler.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
@@ -74,10 +75,16 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private String extractSocialId(Authentication authentication) {
         Object principal = authentication.getPrincipal();
-        if (!(principal instanceof OidcUser oidcUser)) {
-            throw new AuthenticationServiceException("OIDC 사용자 정보가 없습니다.");
+
+        if (principal instanceof OidcUser oidcUser) {
+            return oidcUser.getSubject();
         }
-        return oidcUser.getSubject();
+
+        if (principal instanceof OAuth2User oAuth2User) {
+            return String.valueOf(oAuth2User.getAttribute("id"));
+        }
+
+        throw new AuthenticationServiceException("소셜 로그인 사용자 정보가 없습니다.");
     }
 
     private TokenResponse generateTokens(Long userId) {

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -39,6 +39,15 @@ spring:
               - openid
             client-name: Google
             provider: google
+          github:
+            client-id: client-id
+            client-secret: client-secret
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8080/login/oauth2/code/github
+            scope: read:user
+            client-name: GitHub
+            provider: github
 
         provider:
           kakao:
@@ -55,3 +64,8 @@ spring:
             user-name-attribute: sub
             jwk-set-uri: https://www.googleapis.com/oauth2/v3/certs
             issuer-uri: https://accounts.google.com
+          github:
+            authorization-uri: https://github.com/login/oauth/authorize
+            token-uri: https://github.com/login/oauth/access_token
+            user-info-uri: https://api.github.com/user
+            user-name-attribute: id

--- a/src/test/java/com/prism/statistics/domain/user/enums/RegistrationIdTest.java
+++ b/src/test/java/com/prism/statistics/domain/user/enums/RegistrationIdTest.java
@@ -30,6 +30,15 @@ class RegistrationIdTest {
     }
 
     @Test
+    void 깃허브_이름으로_등록된_RegistrationId를_찾을_수_있다() {
+        // when
+        RegistrationId actual = RegistrationId.findBy("github");
+
+        // then
+        assertThat(actual).isEqualTo(RegistrationId.GITHUB);
+    }
+
+    @Test
     void 등록되지_않은_이름이면_RegistrationId를_찾을_수_없다() {
         // when & then
         assertThatThrownBy(() -> RegistrationId.findBy("invalid"))
@@ -49,6 +58,15 @@ class RegistrationIdTest {
     void 구글_지원하는_RegistrationId_이름인지_여부를_확인한다() {
         // when
         boolean actual = RegistrationId.contains("google");
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void 깃허브_지원하는_RegistrationId_이름인지_여부를_확인한다() {
+        // when
+        boolean actual = RegistrationId.contains("github");
 
         // then
         assertThat(actual).isTrue();


### PR DESCRIPTION
 # 관련 이슈 번호
  - closed #138

  ## 이 PR을 통해 해결하려는 문제가 무엇인가요?
  GitHub OAuth2 로그인 기능을 추가했습니다.
  GitHub은 OIDC를 지원하지 않고 표준 OAuth2만 제공하기 때문에, 기존 OIDC 전용이었던 `extractSocialId()`에 OAuth2User 분기 처리를       추가했습니다.
  ## 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

  - `OAuth2SuccessHandler.extractSocialId()`에서 OidcUser(Kakao, Google)와 OAuth2User(GitHub) 분기 처리 추가
  - `getAttribute("id")` 제네릭 타입 추론으로 인한 `ClassCastException` 수정 (지역 변수로 타입 명시)
  - `RegistrationId` enum에 `GITHUB` 추가
  - `application-security.yml`에 GitHub client registration + provider 설정 추가

  ## 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

  - `RegistrationIdTest`에 GitHub 관련 테스트 케이스 추가
  - 배포 시 DB 마이그레이션이 적용: `ALTER TABLE user_identities MODIFY COLUMN registration_id ENUM('GOOGLE', 'KAKAO', 'GITHUB') NOT NULL;`
  - client 레포지토리에 GitHub으로 로그인 추가

  ## Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
  
  - `extractSocialId()`에서 `OAuth2User.getAttribute("id")`의 반환 타입이 제네릭 `<A>`이기 때문에 `String.valueOf()`에 직접 전달하면 `char[]` 오버로드가 선택되는  문제가 있었습니다. `int` 지역 변수로 받아서 해결했는데, 이 방식이 괜찮은지 의견 부탁드립니다.
      -  null을 고려해서 Integer로 할 수도 있었으나, 애초에 null이면 잘못된 github id 이므로 고려하지 않음