### PR TITLE
처리율 api 쿼리 개선

### DIFF
--- a/src/main/java/com/prism/statistics/infrastructure/statistics/persistence/ThroughputStatisticsRepositoryAdapter.java
+++ b/src/main/java/com/prism/statistics/infrastructure/statistics/persistence/ThroughputStatisticsRepositoryAdapter.java
@@ -92,7 +92,10 @@ public class ThroughputStatisticsRepositoryAdapter implements ThroughputStatisti
             return 0L;
         }
         Long value = tuple.get(expression);
-        return value == null ? 0L : value;
+        if (value == null) {
+            return 0L;
+        }
+        return value;
     }
 
     private BooleanExpression closedAtDateRangeCondition(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/prism/statistics/infrastructure/statistics/persistence/ThroughputStatisticsRepositoryAdapter.java
+++ b/src/main/java/com/prism/statistics/infrastructure/statistics/persistence/ThroughputStatisticsRepositoryAdapter.java
@@ -1,16 +1,20 @@
 package com.prism.statistics.infrastructure.statistics.persistence;
 
-import com.prism.statistics.domain.analysis.metadata.pullrequest.PullRequest;
 import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullRequestState;
 import com.prism.statistics.domain.statistics.repository.ThroughputStatisticsRepository;
 import com.prism.statistics.domain.statistics.repository.dto.ThroughputStatisticsDto;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,30 +35,53 @@ public class ThroughputStatisticsRepositoryAdapter implements ThroughputStatisti
             LocalDate startDate,
             LocalDate endDate
     ) {
-        List<PullRequest> pullRequests = queryFactory
-                .selectFrom(pullRequest)
+        NumberExpression<Long> mergedCountExpression = new CaseBuilder()
+                .when(pullRequest.state.eq(PullRequestState.MERGED)).then(1L)
+                .otherwise(0L)
+                .sumLong()
+                .coalesce(0L);
+
+        NumberExpression<Long> closedCountExpression = new CaseBuilder()
+                .when(pullRequest.state.eq(PullRequestState.CLOSED)).then(1L)
+                .otherwise(0L)
+                .sumLong()
+                .coalesce(0L);
+
+        Tuple countTuple = queryFactory
+                .select(mergedCountExpression, closedCountExpression)
+                .from(pullRequest)
                 .where(
                         pullRequest.projectId.eq(projectId),
                         pullRequest.state.in(PullRequestState.MERGED, PullRequestState.CLOSED),
                         closedAtDateRangeCondition(startDate, endDate)
                 )
-                .fetch();
+                .fetchOne();
 
-        if (pullRequests.isEmpty()) {
+        long mergedCount = resolveLong(countTuple, mergedCountExpression);
+        long closedCount = resolveLong(countTuple, closedCountExpression);
+
+        if (mergedCount == 0L && closedCount == 0L) {
             return Optional.empty();
         }
 
-        long mergedCount = pullRequests.stream()
-                .filter(pr -> pr.isMerged())
-                .count();
+        List<Tuple> mergedTimings = queryFactory
+                .select(
+                        pullRequest.timing.githubCreatedAt,
+                        pullRequest.timing.githubMergedAt
+                )
+                .from(pullRequest)
+                .where(
+                        pullRequest.projectId.eq(projectId),
+                        pullRequest.state.eq(PullRequestState.MERGED),
+                        closedAtDateRangeCondition(startDate, endDate)
+                )
+                .fetch();
 
-        long closedCount = pullRequests.stream()
-                .filter(pr -> pr.isClosed())
-                .count();
-
-        long totalMergeTimeMinutes = pullRequests.stream()
-                .filter(pr -> pr.isMerged())
-                .mapToLong(pr -> pr.calculateMergeTimeMinutes())
+        long totalMergeTimeMinutes = mergedTimings.stream()
+                .mapToLong(row -> calculateMergeMinutes(
+                        row.get(pullRequest.timing.githubCreatedAt),
+                        row.get(pullRequest.timing.githubMergedAt)
+                ))
                 .sum();
 
         return Optional.of(new ThroughputStatisticsDto(
@@ -62,6 +89,22 @@ public class ThroughputStatisticsRepositoryAdapter implements ThroughputStatisti
                 closedCount,
                 totalMergeTimeMinutes
         ));
+    }
+
+    private long resolveLong(Tuple tuple, NumberExpression<Long> expression) {
+        if (tuple == null) {
+            return 0L;
+        }
+        Long value = tuple.get(expression);
+        return value == null ? 0L : value;
+    }
+
+    private long calculateMergeMinutes(LocalDateTime createdAt, LocalDateTime mergedAt) {
+        if (createdAt == null || mergedAt == null) {
+            return 0L;
+        }
+
+        return Duration.between(createdAt, mergedAt).toMinutes();
     }
 
     private BooleanExpression closedAtDateRangeCondition(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/prism/statistics/infrastructure/statistics/persistence/ThroughputStatisticsRepositoryAdapter.java
+++ b/src/main/java/com/prism/statistics/infrastructure/statistics/persistence/ThroughputStatisticsRepositoryAdapter.java
@@ -4,18 +4,16 @@ import com.prism.statistics.domain.analysis.metadata.pullrequest.enums.PullReque
 import com.prism.statistics.domain.statistics.repository.ThroughputStatisticsRepository;
 import com.prism.statistics.domain.statistics.repository.dto.ThroughputStatisticsDto;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import static com.prism.statistics.domain.analysis.metadata.pullrequest.QPullRequest.pullRequest;
@@ -35,8 +33,12 @@ public class ThroughputStatisticsRepositoryAdapter implements ThroughputStatisti
             LocalDate startDate,
             LocalDate endDate
     ) {
+        BooleanExpression validMergedCondition = pullRequest.state.eq(PullRequestState.MERGED)
+                .and(pullRequest.timing.githubCreatedAt.isNotNull())
+                .and(pullRequest.timing.githubMergedAt.isNotNull());
+
         NumberExpression<Long> mergedCountExpression = new CaseBuilder()
-                .when(pullRequest.state.eq(PullRequestState.MERGED)).then(1L)
+                .when(validMergedCondition).then(1L)
                 .otherwise(0L)
                 .sumLong()
                 .coalesce(0L);
@@ -47,8 +49,20 @@ public class ThroughputStatisticsRepositoryAdapter implements ThroughputStatisti
                 .sumLong()
                 .coalesce(0L);
 
-        Tuple countTuple = queryFactory
-                .select(mergedCountExpression, closedCountExpression)
+        NumberExpression<Long> totalMergeTimeMinutesExpression = new CaseBuilder()
+                .when(validMergedCondition)
+                .then(Expressions.numberTemplate(
+                        Long.class,
+                        "TIMESTAMPDIFF(MINUTE, {0}, {1})",
+                        pullRequest.timing.githubCreatedAt,
+                        pullRequest.timing.githubMergedAt
+                ))
+                .otherwise(0L)
+                .sumLong()
+                .coalesce(0L);
+
+        Tuple resultTuple = queryFactory
+                .select(mergedCountExpression, closedCountExpression, totalMergeTimeMinutesExpression)
                 .from(pullRequest)
                 .where(
                         pullRequest.projectId.eq(projectId),
@@ -57,32 +71,14 @@ public class ThroughputStatisticsRepositoryAdapter implements ThroughputStatisti
                 )
                 .fetchOne();
 
-        long mergedCount = resolveLong(countTuple, mergedCountExpression);
-        long closedCount = resolveLong(countTuple, closedCountExpression);
+        long mergedCount = resolveLong(resultTuple, mergedCountExpression);
+        long closedCount = resolveLong(resultTuple, closedCountExpression);
 
         if (mergedCount == 0L && closedCount == 0L) {
             return Optional.empty();
         }
 
-        List<Tuple> mergedTimings = queryFactory
-                .select(
-                        pullRequest.timing.githubCreatedAt,
-                        pullRequest.timing.githubMergedAt
-                )
-                .from(pullRequest)
-                .where(
-                        pullRequest.projectId.eq(projectId),
-                        pullRequest.state.eq(PullRequestState.MERGED),
-                        closedAtDateRangeCondition(startDate, endDate)
-                )
-                .fetch();
-
-        long totalMergeTimeMinutes = mergedTimings.stream()
-                .mapToLong(row -> calculateMergeMinutes(
-                        row.get(pullRequest.timing.githubCreatedAt),
-                        row.get(pullRequest.timing.githubMergedAt)
-                ))
-                .sum();
+        long totalMergeTimeMinutes = resolveLong(resultTuple, totalMergeTimeMinutesExpression);
 
         return Optional.of(new ThroughputStatisticsDto(
                 mergedCount,
@@ -97,14 +93,6 @@ public class ThroughputStatisticsRepositoryAdapter implements ThroughputStatisti
         }
         Long value = tuple.get(expression);
         return value == null ? 0L : value;
-    }
-
-    private long calculateMergeMinutes(LocalDateTime createdAt, LocalDateTime mergedAt) {
-        if (createdAt == null || mergedAt == null) {
-            return 0L;
-        }
-
-        return Duration.between(createdAt, mergedAt).toMinutes();
     }
 
     private BooleanExpression closedAtDateRangeCondition(LocalDate startDate, LocalDate endDate) {


### PR DESCRIPTION
# 관련 이슈 번호
<!-- 해당 PR이 merge되면 닫힐 이슈 번호를 명시해주세요. -->
- closed #141 

## 이 PR을 통해 해결하려는 문제가 무엇인가요?
처리율 통계 API 쿼리를 개선했습니다.

현재는 PR 엔티티 전체를 조회해 상태별 카운트 및 평균 병합 시간을 계산하고 있어 불필요한 데이터 로딩이 발생합니다. 이를 MERGED/CLOSED 카운트는 DB 집계로 계산하고, 평균 병합 시간은 MERGED 대상의 생성/병합 시각만 조회해 합산하도록 개선합니다. 결과가 없을 때의 처리도 명확히 하도록 수정했습니다.

이 과정에서 다음과 같이 API 실행 시간을 개선했습니다

개선 전
검색 조건이 없는 경우 : 최대 6994ms, 5687ms / 최소 3563ms / 중간 3869ms

개선 후
검색 조건이 없는 경우 : 0.06ms로 단축

<!-- 어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요. -->
<!-- 일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요. -->

## 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

처리율 통계 조회 쿼리 리팩터링

상태별 카운트 집계 로직을 DB 집계 방식으로 변경

병합 시간 계산을 타임스탬프 조회 + Duration 계산 방식으로 변경

결과 없음 케이스(0/0) 처리 및 null 안전 보강

<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요. -->

## 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
없음
<!-- 없으면 "없음" 이라고 기재해 주세요 -->

## Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
<!-- 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요. -->
