### PR TITLE
CollectInbox 도메인 모델과 JPA 엔티티 분리

### DIFF
--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInbox.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInbox.java
@@ -61,6 +61,7 @@ public class CollectInbox {
             BoxEventTime failedTime,
             CollectInboxFailureSnapshot failure
     ) {
+        validateId(id);
         validateCollectType(collectType);
         validateRunId(runId);
         validatePayloadJson(payloadJson);
@@ -160,6 +161,12 @@ public class CollectInbox {
         this.processedTime = BoxEventTime.absent();
         this.failedTime = BoxEventTime.present(failedAt);
         this.failure = CollectInboxFailureSnapshot.present(failureReason, failureType);
+    }
+
+    private static void validateId(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("rehydrate 시 id는 비어 있을 수 없습니다.");
+        }
     }
 
     private static void validateCollectType(CollectInboxType collectType) {

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInbox.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInbox.java
@@ -240,8 +240,12 @@ public class CollectInbox {
             validateRetryPendingState(processingAttempt, processingLease, processedTime, failedTime, failure);
             return;
         }
+        if (status == CollectInboxStatus.FAILED) {
+            validateFailedState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
 
-        validateFailedState(processingAttempt, processingLease, processedTime, failedTime, failure);
+        throw new IllegalStateException("알 수 없는 상태입니다: " + status);
     }
 
     private static void validatePendingState(

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInbox.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInbox.java
@@ -1,47 +1,26 @@
 package com.prism.statistics.infrastructure.collect.inbox;
 
-import com.prism.statistics.domain.common.BaseTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import com.prism.statistics.infrastructure.common.BoxEventTime;
+import com.prism.statistics.infrastructure.common.BoxProcessingLease;
 import java.time.Instant;
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
-@Table(name = "collect_inbox")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CollectInbox extends BaseTimeEntity {
+public class CollectInbox {
 
-    @Enumerated(EnumType.STRING)
-    private CollectInboxType collectType;
+    private final Long id;
+    private final CollectInboxType collectType;
+    private final Long projectId;
+    private final long runId;
+    private final String payloadJson;
 
-    private Long projectId;
-
-    private long runId;
-
-    @Lob
-    private String payloadJson;
-
-    @Enumerated(EnumType.STRING)
     private CollectInboxStatus status;
-
     private int processingAttempt;
-
-    private Instant processingStartedAt;
-
-    private Instant processedAt;
-
-    private Instant failedAt;
-
-    private String failureReason;
-
-    @Enumerated(EnumType.STRING)
-    private CollectInboxFailureType failureType;
+    private BoxProcessingLease processingLease;
+    private BoxEventTime processedTime;
+    private BoxEventTime failedTime;
+    private CollectInboxFailureSnapshot failure;
 
     public static CollectInbox pending(
             CollectInboxType collectType,
@@ -54,29 +33,84 @@ public class CollectInbox extends BaseTimeEntity {
         validatePayloadJson(payloadJson);
 
         return new CollectInbox(
+                null,
                 collectType,
                 projectId,
                 runId,
                 payloadJson,
                 CollectInboxStatus.PENDING,
-                0
+                0,
+                BoxProcessingLease.idle(),
+                BoxEventTime.absent(),
+                BoxEventTime.absent(),
+                CollectInboxFailureSnapshot.absent()
         );
     }
 
-    private CollectInbox(
+    @Builder(builderMethodName = "rehydrateBuilder")
+    private static CollectInbox rehydrate(
+            Long id,
             CollectInboxType collectType,
             Long projectId,
             long runId,
             String payloadJson,
             CollectInboxStatus status,
-            int processingAttempt
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure
     ) {
+        validateCollectType(collectType);
+        validateRunId(runId);
+        validatePayloadJson(payloadJson);
+        validateStatus(status);
+        validateProcessingAttempt(processingAttempt);
+        validateProcessingLease(processingLease);
+        validateProcessedTime(processedTime);
+        validateFailedTime(failedTime);
+        validateFailure(failure);
+        validateState(status, processingAttempt, processingLease, processedTime, failedTime, failure);
+
+        return new CollectInbox(
+                id,
+                collectType,
+                projectId,
+                runId,
+                payloadJson,
+                status,
+                processingAttempt,
+                processingLease,
+                processedTime,
+                failedTime,
+                failure
+        );
+    }
+
+    private CollectInbox(
+            Long id,
+            CollectInboxType collectType,
+            Long projectId,
+            long runId,
+            String payloadJson,
+            CollectInboxStatus status,
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure
+    ) {
+        this.id = id;
         this.collectType = collectType;
         this.projectId = projectId;
         this.runId = runId;
         this.payloadJson = payloadJson;
         this.status = status;
         this.processingAttempt = processingAttempt;
+        this.processingLease = processingLease;
+        this.processedTime = processedTime;
+        this.failedTime = failedTime;
+        this.failure = failure;
     }
 
     public void markProcessed(Instant processedAt) {
@@ -84,23 +118,31 @@ public class CollectInbox extends BaseTimeEntity {
         validateTransition(CollectInboxStatus.PROCESSING, "PROCESSED");
 
         this.status = CollectInboxStatus.PROCESSED;
-        this.processingStartedAt = null;
-        this.processedAt = processedAt;
-        this.failureReason = null;
-        this.failureType = null;
-        this.failedAt = null;
+        this.processingLease = BoxProcessingLease.idle();
+        this.processedTime = BoxEventTime.present(processedAt);
+        this.failedTime = BoxEventTime.absent();
+        this.failure = CollectInboxFailureSnapshot.absent();
     }
 
     public void markRetryPending(Instant failedAt, String failureReason) {
+        markRetryPending(failedAt, failureReason, CollectInboxFailureType.RETRYABLE);
+    }
+
+    public void markRetryPending(
+            Instant failedAt,
+            String failureReason,
+            CollectInboxFailureType failureType
+    ) {
         validateFailedAt(failedAt);
         validateFailureReason(failureReason);
+        validateRetryPendingFailureType(failureType);
         validateTransition(CollectInboxStatus.PROCESSING, "RETRY_PENDING");
 
         this.status = CollectInboxStatus.RETRY_PENDING;
-        this.processingStartedAt = null;
-        this.failedAt = failedAt;
-        this.failureReason = failureReason;
-        this.failureType = null;
+        this.processingLease = BoxProcessingLease.idle();
+        this.processedTime = BoxEventTime.absent();
+        this.failedTime = BoxEventTime.present(failedAt);
+        this.failure = CollectInboxFailureSnapshot.present(failureReason, failureType);
     }
 
     public void markFailed(
@@ -110,14 +152,14 @@ public class CollectInbox extends BaseTimeEntity {
     ) {
         validateFailedAt(failedAt);
         validateFailureReason(failureReason);
-        validateFailureType(failureType);
+        validateFailedFailureType(failureType);
         validateTransition(CollectInboxStatus.PROCESSING, "FAILED");
 
         this.status = CollectInboxStatus.FAILED;
-        this.processingStartedAt = null;
-        this.failedAt = failedAt;
-        this.failureReason = failureReason;
-        this.failureType = failureType;
+        this.processingLease = BoxProcessingLease.idle();
+        this.processedTime = BoxEventTime.absent();
+        this.failedTime = BoxEventTime.present(failedAt);
+        this.failure = CollectInboxFailureSnapshot.present(failureReason, failureType);
     }
 
     private static void validateCollectType(CollectInboxType collectType) {
@@ -135,6 +177,201 @@ public class CollectInbox extends BaseTimeEntity {
     private static void validatePayloadJson(String payloadJson) {
         if (payloadJson == null || payloadJson.isBlank()) {
             throw new IllegalArgumentException("payloadJson은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateStatus(CollectInboxStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("status는 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateProcessingAttempt(int processingAttempt) {
+        if (processingAttempt < 0) {
+            throw new IllegalArgumentException("processingAttempt는 0 이상이어야 합니다.");
+        }
+    }
+
+    private static void validateProcessingLease(BoxProcessingLease processingLease) {
+        if (processingLease == null) {
+            throw new IllegalArgumentException("processingLease는 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateProcessedTime(BoxEventTime processedTime) {
+        if (processedTime == null) {
+            throw new IllegalArgumentException("processedTime은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateFailedTime(BoxEventTime failedTime) {
+        if (failedTime == null) {
+            throw new IllegalArgumentException("failedTime은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateFailure(CollectInboxFailureSnapshot failure) {
+        if (failure == null) {
+            throw new IllegalArgumentException("failure는 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateState(
+            CollectInboxStatus status,
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure
+    ) {
+        if (status == CollectInboxStatus.PENDING) {
+            validatePendingState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
+        if (status == CollectInboxStatus.PROCESSING) {
+            validateProcessingState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
+        if (status == CollectInboxStatus.PROCESSED) {
+            validateProcessedState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
+        if (status == CollectInboxStatus.RETRY_PENDING) {
+            validateRetryPendingState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
+
+        validateFailedState(processingAttempt, processingLease, processedTime, failedTime, failure);
+    }
+
+    private static void validatePendingState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure
+    ) {
+        if (processingAttempt != 0) {
+            throw new IllegalArgumentException("PENDING 상태의 processingAttempt는 0이어야 합니다.");
+        }
+        validateIdleLease(processingLease, "PENDING");
+        validateProcessedTimeAbsent(processedTime, "PENDING");
+        validateFailedStateAbsent(failedTime, failure, "PENDING");
+    }
+
+    private static void validateProcessingState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure
+    ) {
+        validateProcessedAttemptStarted(processingAttempt, "PROCESSING");
+        if (!processingLease.isClaimed()) {
+            throw new IllegalArgumentException("PROCESSING 상태는 processingLease를 보유해야 합니다.");
+        }
+        validateProcessedTimeAbsent(processedTime, "PROCESSING");
+        validateFailedStateAbsent(failedTime, failure, "PROCESSING");
+    }
+
+    private static void validateProcessedState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure
+    ) {
+        validateProcessedAttemptStarted(processingAttempt, "PROCESSED");
+        validateIdleLease(processingLease, "PROCESSED");
+        if (!processedTime.isPresent()) {
+            throw new IllegalArgumentException("PROCESSED 상태는 processedTime이 있어야 합니다.");
+        }
+        validateFailedStateAbsent(failedTime, failure, "PROCESSED");
+    }
+
+    private static void validateRetryPendingState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure
+    ) {
+        validateProcessedAttemptStarted(processingAttempt, "RETRY_PENDING");
+        validateIdleLease(processingLease, "RETRY_PENDING");
+        validateProcessedTimeAbsent(processedTime, "RETRY_PENDING");
+        validateFailedStatePresent(failedTime, failure, "RETRY_PENDING");
+
+        CollectInboxFailureType failureType = failure.type();
+        if (failureType == CollectInboxFailureType.RETRYABLE
+                || failureType == CollectInboxFailureType.PROCESSING_TIMEOUT) {
+            return;
+        }
+
+        throw new IllegalArgumentException("RETRY_PENDING 상태의 failureType이 올바르지 않습니다.");
+    }
+
+    private static void validateFailedState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure
+    ) {
+        validateProcessedAttemptStarted(processingAttempt, "FAILED");
+        validateIdleLease(processingLease, "FAILED");
+        validateProcessedTimeAbsent(processedTime, "FAILED");
+        validateFailedStatePresent(failedTime, failure, "FAILED");
+
+        CollectInboxFailureType failureType = failure.type();
+        if (failureType == CollectInboxFailureType.BUSINESS_INVARIANT
+                || failureType == CollectInboxFailureType.RETRY_EXHAUSTED) {
+            return;
+        }
+
+        throw new IllegalArgumentException("FAILED 상태의 failureType이 올바르지 않습니다.");
+    }
+
+    private static void validateProcessedAttemptStarted(int processingAttempt, String statusName) {
+        if (processingAttempt <= 0) {
+            throw new IllegalArgumentException(statusName + " 상태의 processingAttempt는 1 이상이어야 합니다.");
+        }
+    }
+
+    private static void validateIdleLease(BoxProcessingLease processingLease, String statusName) {
+        if (processingLease.isClaimed()) {
+            throw new IllegalArgumentException(statusName + " 상태는 processingLease가 비어 있어야 합니다.");
+        }
+    }
+
+    private static void validateProcessedTimeAbsent(BoxEventTime processedTime, String statusName) {
+        if (processedTime.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 processedTime이 비어 있어야 합니다.");
+        }
+    }
+
+    private static void validateFailedStateAbsent(
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure,
+            String statusName
+    ) {
+        if (failedTime.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 failedTime이 비어 있어야 합니다.");
+        }
+        if (failure.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 failure가 비어 있어야 합니다.");
+        }
+    }
+
+    private static void validateFailedStatePresent(
+            BoxEventTime failedTime,
+            CollectInboxFailureSnapshot failure,
+            String statusName
+    ) {
+        if (!failedTime.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 failedTime이 있어야 합니다.");
+        }
+        if (!failure.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 failure가 있어야 합니다.");
         }
     }
 
@@ -156,10 +393,20 @@ public class CollectInbox extends BaseTimeEntity {
         }
     }
 
-    private void validateFailureType(CollectInboxFailureType failureType) {
-        if (failureType == null) {
-            throw new IllegalArgumentException("failureType은 비어 있을 수 없습니다.");
+    private void validateRetryPendingFailureType(CollectInboxFailureType failureType) {
+        if (failureType != null && failureType.allowedInRetryPending()) {
+            return;
         }
+
+        throw new IllegalArgumentException("RETRY_PENDING failureType이 올바르지 않습니다.");
+    }
+
+    private void validateFailedFailureType(CollectInboxFailureType failureType) {
+        if (failureType != null && failureType.allowedInFailed()) {
+            return;
+        }
+
+        throw new IllegalArgumentException("FAILED failureType이 올바르지 않습니다.");
     }
 
     private void validateTransition(CollectInboxStatus expectedStatus, String targetStatus) {

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxFailureSnapshot.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxFailureSnapshot.java
@@ -5,7 +5,7 @@ public sealed interface CollectInboxFailureSnapshot
         CollectInboxFailureSnapshot.PresentCollectInboxFailureSnapshot {
 
     static CollectInboxFailureSnapshot absent() {
-        return new AbsentCollectInboxFailureSnapshot();
+        return AbsentCollectInboxFailureSnapshot.INSTANCE;
     }
 
     static CollectInboxFailureSnapshot present(String reason, CollectInboxFailureType type) {
@@ -30,6 +30,12 @@ public sealed interface CollectInboxFailureSnapshot
     }
 
     final class AbsentCollectInboxFailureSnapshot implements CollectInboxFailureSnapshot {
+
+        private static final AbsentCollectInboxFailureSnapshot INSTANCE =
+                new AbsentCollectInboxFailureSnapshot();
+
+        private AbsentCollectInboxFailureSnapshot() {
+        }
 
         @Override
         public boolean isPresent() {

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxFailureSnapshot.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxFailureSnapshot.java
@@ -1,0 +1,57 @@
+package com.prism.statistics.infrastructure.collect.inbox;
+
+public sealed interface CollectInboxFailureSnapshot
+        permits CollectInboxFailureSnapshot.AbsentCollectInboxFailureSnapshot,
+        CollectInboxFailureSnapshot.PresentCollectInboxFailureSnapshot {
+
+    static CollectInboxFailureSnapshot absent() {
+        return new AbsentCollectInboxFailureSnapshot();
+    }
+
+    static CollectInboxFailureSnapshot present(String reason, CollectInboxFailureType type) {
+        if (reason == null || reason.isBlank()) {
+            throw new IllegalArgumentException("failureReason은 비어 있을 수 없습니다.");
+        }
+        if (type == null) {
+            throw new IllegalArgumentException("failureType은 비어 있을 수 없습니다.");
+        }
+
+        return new PresentCollectInboxFailureSnapshot(reason, type);
+    }
+
+    boolean isPresent();
+
+    default String reason() {
+        throw new IllegalStateException("실패 정보가 없는 상태입니다.");
+    }
+
+    default CollectInboxFailureType type() {
+        throw new IllegalStateException("실패 정보가 없는 상태입니다.");
+    }
+
+    final class AbsentCollectInboxFailureSnapshot implements CollectInboxFailureSnapshot {
+
+        @Override
+        public boolean isPresent() {
+            return false;
+        }
+    }
+
+    record PresentCollectInboxFailureSnapshot(String reason, CollectInboxFailureType type)
+            implements CollectInboxFailureSnapshot {
+
+        public PresentCollectInboxFailureSnapshot {
+            if (reason == null || reason.isBlank()) {
+                throw new IllegalArgumentException("failureReason은 비어 있을 수 없습니다.");
+            }
+            if (type == null) {
+                throw new IllegalArgumentException("failureType은 비어 있을 수 없습니다.");
+            }
+        }
+
+        @Override
+        public boolean isPresent() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxFailureType.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxFailureType.java
@@ -2,6 +2,16 @@ package com.prism.statistics.infrastructure.collect.inbox;
 
 public enum CollectInboxFailureType {
 
+    RETRYABLE,
+    PROCESSING_TIMEOUT,
     BUSINESS_INVARIANT,
-    RETRY_EXHAUSTED
+    RETRY_EXHAUSTED;
+
+    public boolean allowedInRetryPending() {
+        return this == RETRYABLE || this == PROCESSING_TIMEOUT;
+    }
+
+    public boolean allowedInFailed() {
+        return this == BUSINESS_INVARIANT || this == RETRY_EXHAUSTED;
+    }
 }

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxCreator.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxCreator.java
@@ -16,7 +16,9 @@ public class CollectInboxCreator {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveNew(CollectInbox inbox) {
-        repository.save(inbox);
+        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
+        entity.apply(inbox);
+        repository.save(entity);
         entityManager.flush();
     }
 }

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxJpaEntity.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxJpaEntity.java
@@ -1,0 +1,150 @@
+package com.prism.statistics.infrastructure.collect.inbox.persistence;
+
+import com.prism.statistics.domain.common.BaseTimeEntity;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInbox;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureType;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxStatus;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxType;
+import com.prism.statistics.infrastructure.common.BoxEventTime;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureSnapshot;
+import com.prism.statistics.infrastructure.common.BoxProcessingLease;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "collect_inbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CollectInboxJpaEntity extends BaseTimeEntity {
+
+    @Enumerated(EnumType.STRING)
+    private CollectInboxType collectType;
+
+    private Long projectId;
+
+    private long runId;
+
+    @Lob
+    private String payloadJson;
+
+    @Enumerated(EnumType.STRING)
+    private CollectInboxStatus status;
+
+    private int processingAttempt;
+
+    private Instant processingStartedAt;
+
+    private Instant processedAt;
+
+    private Instant failedAt;
+
+    private String failureReason;
+
+    @Enumerated(EnumType.STRING)
+    private CollectInboxFailureType failureType;
+
+    public CollectInbox toDomain() {
+        return CollectInbox.rehydrateBuilder()
+                .id(getId())
+                .collectType(collectType)
+                .projectId(projectId)
+                .runId(runId)
+                .payloadJson(payloadJson)
+                .status(status)
+                .processingAttempt(processingAttempt)
+                .processingLease(toProcessingLease())
+                .processedTime(toProcessedTime())
+                .failedTime(toFailedTime())
+                .failure(toFailure())
+                .build();
+    }
+
+    public void apply(CollectInbox inbox) {
+        this.collectType = inbox.getCollectType();
+        this.projectId = inbox.getProjectId();
+        this.runId = inbox.getRunId();
+        this.payloadJson = inbox.getPayloadJson();
+        this.status = inbox.getStatus();
+        this.processingAttempt = inbox.getProcessingAttempt();
+        applyProcessingLease(inbox);
+        applyProcessedTime(inbox);
+        applyFailedTime(inbox);
+        applyFailure(inbox);
+    }
+
+    private void applyProcessingLease(CollectInbox inbox) {
+        this.processingStartedAt = null;
+        if (inbox.getProcessingLease().isClaimed()) {
+            this.processingStartedAt = inbox.getProcessingLease().startedAt();
+        }
+    }
+
+    private void applyProcessedTime(CollectInbox inbox) {
+        this.processedAt = null;
+        if (inbox.getProcessedTime().isPresent()) {
+            this.processedAt = inbox.getProcessedTime().occurredAt();
+        }
+    }
+
+    private void applyFailedTime(CollectInbox inbox) {
+        this.failedAt = null;
+        if (inbox.getFailedTime().isPresent()) {
+            this.failedAt = inbox.getFailedTime().occurredAt();
+        }
+    }
+
+    private void applyFailure(CollectInbox inbox) {
+        this.failureReason = null;
+        this.failureType = null;
+
+        CollectInboxFailureSnapshot failure = inbox.getFailure();
+        if (!failure.isPresent()) {
+            return;
+        }
+
+        this.failureReason = failure.reason();
+        this.failureType = failure.type();
+    }
+
+    private BoxProcessingLease toProcessingLease() {
+        if (processingStartedAt == null) {
+            return BoxProcessingLease.idle();
+        }
+
+        return BoxProcessingLease.claimed(processingStartedAt);
+    }
+
+    private BoxEventTime toProcessedTime() {
+        if (processedAt == null) {
+            return BoxEventTime.absent();
+        }
+
+        return BoxEventTime.present(processedAt);
+    }
+
+    private BoxEventTime toFailedTime() {
+        if (failedAt == null) {
+            return BoxEventTime.absent();
+        }
+
+        return BoxEventTime.present(failedAt);
+    }
+
+    private CollectInboxFailureSnapshot toFailure() {
+        if (failureReason == null && failureType == null) {
+            return CollectInboxFailureSnapshot.absent();
+        }
+        if (failureReason == null || failureType == null) {
+            throw new IllegalStateException("failure 상태가 올바르지 않습니다.");
+        }
+
+        return CollectInboxFailureSnapshot.present(failureReason, failureType);
+    }
+}

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxRepositoryAdapter.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxRepositoryAdapter.java
@@ -1,6 +1,6 @@
 package com.prism.statistics.infrastructure.collect.inbox.persistence;
 
-import static com.prism.statistics.infrastructure.collect.inbox.QCollectInbox.collectInbox;
+import static com.prism.statistics.infrastructure.collect.inbox.persistence.QCollectInboxJpaEntity.collectInboxJpaEntity;
 
 import com.prism.statistics.infrastructure.collect.inbox.CollectInbox;
 import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureType;
@@ -57,33 +57,43 @@ public class CollectInboxRepositoryAdapter implements CollectInboxRepository {
         }
 
         return queryFactory
-                .selectFrom(collectInbox)
-                .where(collectInbox.status.in(CLAIMABLE_STATUSES))
-                .orderBy(collectInbox.id.asc())
+                .selectFrom(collectInboxJpaEntity)
+                .where(collectInboxJpaEntity.status.in(CLAIMABLE_STATUSES))
+                .orderBy(collectInboxJpaEntity.id.asc())
                 .limit(limit)
-                .fetch();
+                .fetch()
+                .stream()
+                .map(inboxJpaEntity -> inboxJpaEntity.toDomain())
+                .toList();
     }
 
     @Override
     @Transactional(readOnly = true)
     public Optional<CollectInbox> findById(Long inboxId) {
-        return repository.findById(inboxId);
+        return repository.findDomainById(inboxId);
     }
 
     @Override
     @Transactional
     public boolean markProcessingIfClaimable(Long inboxId, Instant processingStartedAt) {
         long updatedCount = queryFactory
-                .update(collectInbox)
-                .set(collectInbox.status, CollectInboxStatus.PROCESSING)
-                .set(collectInbox.processingAttempt, collectInbox.processingAttempt.add(1))
-                .set(collectInbox.processingStartedAt, processingStartedAt)
-                .set(collectInbox.failedAt, Expressions.nullExpression(Instant.class))
-                .set(collectInbox.failureReason, Expressions.nullExpression(String.class))
-                .set(collectInbox.failureType, Expressions.nullExpression(CollectInboxFailureType.class))
+                .update(collectInboxJpaEntity)
+                .set(collectInboxJpaEntity.status, CollectInboxStatus.PROCESSING)
+                .set(
+                        collectInboxJpaEntity.processingAttempt,
+                        collectInboxJpaEntity.processingAttempt.add(1)
+                )
+                .set(collectInboxJpaEntity.processingStartedAt, processingStartedAt)
+                .set(collectInboxJpaEntity.processedAt, Expressions.nullExpression(Instant.class))
+                .set(collectInboxJpaEntity.failedAt, Expressions.nullExpression(Instant.class))
+                .set(collectInboxJpaEntity.failureReason, Expressions.nullExpression(String.class))
+                .set(
+                        collectInboxJpaEntity.failureType,
+                        Expressions.nullExpression(CollectInboxFailureType.class)
+                )
                 .where(
-                        collectInbox.id.eq(inboxId),
-                        collectInbox.status.in(CLAIMABLE_STATUSES)
+                        collectInboxJpaEntity.id.eq(inboxId),
+                        collectInboxJpaEntity.status.in(CLAIMABLE_STATUSES)
                 )
                 .execute();
 
@@ -98,34 +108,36 @@ public class CollectInboxRepositoryAdapter implements CollectInboxRepository {
             String failureReason,
             int maxAttempts
     ) {
-        BooleanExpression timeoutCondition = collectInbox.processingStartedAt.isNull()
-                .or(collectInbox.processingStartedAt.lt(processingStartedBefore));
+        BooleanExpression timeoutCondition = collectInboxJpaEntity.processingStartedAt.isNull()
+                .or(collectInboxJpaEntity.processingStartedAt.lt(processingStartedBefore));
 
         long exhaustedCount = queryFactory
-                .update(collectInbox)
-                .set(collectInbox.status, CollectInboxStatus.FAILED)
-                .set(collectInbox.processingStartedAt, Expressions.nullExpression(Instant.class))
-                .set(collectInbox.failedAt, failedAt)
-                .set(collectInbox.failureReason, failureReason)
-                .set(collectInbox.failureType, CollectInboxFailureType.RETRY_EXHAUSTED)
+                .update(collectInboxJpaEntity)
+                .set(collectInboxJpaEntity.status, CollectInboxStatus.FAILED)
+                .set(collectInboxJpaEntity.processingStartedAt, Expressions.nullExpression(Instant.class))
+                .set(collectInboxJpaEntity.processedAt, Expressions.nullExpression(Instant.class))
+                .set(collectInboxJpaEntity.failedAt, failedAt)
+                .set(collectInboxJpaEntity.failureReason, failureReason)
+                .set(collectInboxJpaEntity.failureType, CollectInboxFailureType.RETRY_EXHAUSTED)
                 .where(
-                        collectInbox.status.eq(CollectInboxStatus.PROCESSING),
+                        collectInboxJpaEntity.status.eq(CollectInboxStatus.PROCESSING),
                         timeoutCondition,
-                        collectInbox.processingAttempt.goe(maxAttempts)
+                        collectInboxJpaEntity.processingAttempt.goe(maxAttempts)
                 )
                 .execute();
 
         long recoveredCount = queryFactory
-                .update(collectInbox)
-                .set(collectInbox.status, CollectInboxStatus.RETRY_PENDING)
-                .set(collectInbox.processingStartedAt, Expressions.nullExpression(Instant.class))
-                .set(collectInbox.failedAt, failedAt)
-                .set(collectInbox.failureReason, failureReason)
-                .set(collectInbox.failureType, Expressions.nullExpression(CollectInboxFailureType.class))
+                .update(collectInboxJpaEntity)
+                .set(collectInboxJpaEntity.status, CollectInboxStatus.RETRY_PENDING)
+                .set(collectInboxJpaEntity.processingStartedAt, Expressions.nullExpression(Instant.class))
+                .set(collectInboxJpaEntity.processedAt, Expressions.nullExpression(Instant.class))
+                .set(collectInboxJpaEntity.failedAt, failedAt)
+                .set(collectInboxJpaEntity.failureReason, failureReason)
+                .set(collectInboxJpaEntity.failureType, CollectInboxFailureType.PROCESSING_TIMEOUT)
                 .where(
-                        collectInbox.status.eq(CollectInboxStatus.PROCESSING),
+                        collectInboxJpaEntity.status.eq(CollectInboxStatus.PROCESSING),
                         timeoutCondition,
-                        collectInbox.processingAttempt.lt(maxAttempts)
+                        collectInboxJpaEntity.processingAttempt.lt(maxAttempts)
                 )
                 .execute();
 
@@ -135,6 +147,16 @@ public class CollectInboxRepositoryAdapter implements CollectInboxRepository {
     @Override
     @Transactional
     public CollectInbox save(CollectInbox inbox) {
-        return repository.save(inbox);
+        Long inboxId = inbox.getId();
+        if (inboxId == null) {
+            CollectInboxJpaEntity newEntity = new CollectInboxJpaEntity();
+            newEntity.apply(inbox);
+            return repository.save(newEntity).toDomain();
+        }
+
+        CollectInboxJpaEntity persistedEntity = repository.findById(inboxId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 collectInbox입니다. id=" + inboxId));
+        persistedEntity.apply(inbox);
+        return repository.save(persistedEntity).toDomain();
     }
 }

--- a/src/main/java/com/prism/statistics/infrastructure/collect/inbox/persistence/JpaCollectInboxRepository.java
+++ b/src/main/java/com/prism/statistics/infrastructure/collect/inbox/persistence/JpaCollectInboxRepository.java
@@ -1,7 +1,12 @@
 package com.prism.statistics.infrastructure.collect.inbox.persistence;
 
 import com.prism.statistics.infrastructure.collect.inbox.CollectInbox;
+import java.util.Optional;
 import org.springframework.data.repository.ListCrudRepository;
 
-public interface JpaCollectInboxRepository extends ListCrudRepository<CollectInbox, Long> {
+public interface JpaCollectInboxRepository extends ListCrudRepository<CollectInboxJpaEntity, Long> {
+
+    default Optional<CollectInbox> findDomainById(Long id) {
+        return findById(id).map(entity -> entity.toDomain());
+    }
 }

--- a/src/main/java/com/prism/statistics/infrastructure/common/BoxEventTime.java
+++ b/src/main/java/com/prism/statistics/infrastructure/common/BoxEventTime.java
@@ -1,0 +1,51 @@
+package com.prism.statistics.infrastructure.common;
+
+import java.time.Instant;
+
+public sealed interface BoxEventTime permits BoxEventTime.AbsentBoxEventTime, BoxEventTime.PresentBoxEventTime {
+
+    static BoxEventTime absent() {
+        return AbsentBoxEventTime.INSTANCE;
+    }
+
+    static BoxEventTime present(Instant occurredAt) {
+        if (occurredAt == null) {
+            throw new IllegalArgumentException("occurredAt은 비어 있을 수 없습니다.");
+        }
+
+        return new PresentBoxEventTime(occurredAt);
+    }
+
+    boolean isPresent();
+
+    default Instant occurredAt() {
+        throw new IllegalStateException("발생 시각이 없는 상태입니다.");
+    }
+
+    final class AbsentBoxEventTime implements BoxEventTime {
+
+        private static final AbsentBoxEventTime INSTANCE = new AbsentBoxEventTime();
+
+        private AbsentBoxEventTime() {
+        }
+
+        @Override
+        public boolean isPresent() {
+            return false;
+        }
+    }
+
+    record PresentBoxEventTime(Instant occurredAt) implements BoxEventTime {
+
+        public PresentBoxEventTime {
+            if (occurredAt == null) {
+                throw new IllegalArgumentException("occurredAt은 비어 있을 수 없습니다.");
+            }
+        }
+
+        @Override
+        public boolean isPresent() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/prism/statistics/infrastructure/common/BoxProcessingLease.java
+++ b/src/main/java/com/prism/statistics/infrastructure/common/BoxProcessingLease.java
@@ -1,0 +1,52 @@
+package com.prism.statistics.infrastructure.common;
+
+import java.time.Instant;
+
+public sealed interface BoxProcessingLease
+        permits BoxProcessingLease.IdleBoxProcessingLease, BoxProcessingLease.ClaimedBoxProcessingLease {
+
+    static BoxProcessingLease idle() {
+        return IdleBoxProcessingLease.INSTANCE;
+    }
+
+    static BoxProcessingLease claimed(Instant startedAt) {
+        if (startedAt == null) {
+            throw new IllegalArgumentException("processingStartedAt은 비어 있을 수 없습니다.");
+        }
+
+        return new ClaimedBoxProcessingLease(startedAt);
+    }
+
+    boolean isClaimed();
+
+    default Instant startedAt() {
+        throw new IllegalStateException("lease를 보유하지 않은 상태입니다.");
+    }
+
+    final class IdleBoxProcessingLease implements BoxProcessingLease {
+
+        private static final IdleBoxProcessingLease INSTANCE = new IdleBoxProcessingLease();
+
+        private IdleBoxProcessingLease() {
+        }
+
+        @Override
+        public boolean isClaimed() {
+            return false;
+        }
+    }
+
+    record ClaimedBoxProcessingLease(Instant startedAt) implements BoxProcessingLease {
+
+        public ClaimedBoxProcessingLease {
+            if (startedAt == null) {
+                throw new IllegalArgumentException("processingStartedAt은 비어 있을 수 없습니다.");
+            }
+        }
+
+        @Override
+        public boolean isClaimed() {
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/prism/statistics/application/collect/inbox/CollectInboxClaimedExecutorTest.java
+++ b/src/test/java/com/prism/statistics/application/collect/inbox/CollectInboxClaimedExecutorTest.java
@@ -14,6 +14,9 @@ import com.prism.statistics.infrastructure.collect.inbox.CollectInbox;
 import com.prism.statistics.infrastructure.collect.inbox.CollectInboxStatus;
 import com.prism.statistics.infrastructure.collect.inbox.CollectInboxType;
 import com.prism.statistics.infrastructure.collect.inbox.repository.CollectInboxRepository;
+import com.prism.statistics.infrastructure.common.BoxEventTime;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureSnapshot;
+import com.prism.statistics.infrastructure.common.BoxProcessingLease;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -24,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @SuppressWarnings("NonAsciiCharacters")
 @ExtendWith(MockitoExtension.class)
@@ -62,7 +64,7 @@ class CollectInboxClaimedExecutorTest {
         // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.PROCESSED),
-                () -> assertThat(inbox.getProcessedAt()).isEqualTo(fixedClock.instant())
+                () -> assertThat(inbox.getProcessedTime().occurredAt()).isEqualTo(fixedClock.instant())
         );
         verify(collectInboxEventRouter).route(
                 eq(new CollectInboxContext(1L, "{}")),
@@ -91,10 +93,18 @@ class CollectInboxClaimedExecutorTest {
     }
 
     private CollectInbox createProcessingInbox() {
-        CollectInbox inbox = CollectInbox.pending(
-                CollectInboxType.PULL_REQUEST_OPENED, 1L, 1L, "{}"
-        );
-        ReflectionTestUtils.setField(inbox, "status", CollectInboxStatus.PROCESSING);
-        return inbox;
+        return CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(CollectInboxType.PULL_REQUEST_OPENED)
+                .projectId(1L)
+                .runId(1L)
+                .payloadJson("{}")
+                .status(CollectInboxStatus.PROCESSING)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.claimed(Instant.parse("2026-03-16T00:00:00Z")))
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.absent())
+                .failure(CollectInboxFailureSnapshot.absent())
+                .build();
     }
 }

--- a/src/test/java/com/prism/statistics/application/collect/inbox/CollectInboxEntryProcessorTest.java
+++ b/src/test/java/com/prism/statistics/application/collect/inbox/CollectInboxEntryProcessorTest.java
@@ -16,6 +16,9 @@ import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureType
 import com.prism.statistics.infrastructure.collect.inbox.CollectInboxStatus;
 import com.prism.statistics.infrastructure.collect.inbox.CollectInboxType;
 import com.prism.statistics.infrastructure.collect.inbox.repository.CollectInboxRepository;
+import com.prism.statistics.infrastructure.common.BoxEventTime;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureSnapshot;
+import com.prism.statistics.infrastructure.common.BoxProcessingLease;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -28,7 +31,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.QueryTimeoutException;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @SuppressWarnings("NonAsciiCharacters")
 @ExtendWith(MockitoExtension.class)
@@ -125,7 +127,7 @@ class CollectInboxEntryProcessorTest {
         // then
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(CollectInboxStatus.RETRY_PENDING),
-                () -> assertThat(actual.getFailureType()).isNull()
+                () -> assertThat(actual.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRYABLE)
         );
         verify(collectInboxRepository).save(actual);
     }
@@ -150,7 +152,7 @@ class CollectInboxEntryProcessorTest {
         // then
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(CollectInboxStatus.FAILED),
-                () -> assertThat(actual.getFailureType()).isEqualTo(CollectInboxFailureType.BUSINESS_INVARIANT)
+                () -> assertThat(actual.getFailure().type()).isEqualTo(CollectInboxFailureType.BUSINESS_INVARIANT)
         );
         verify(collectInboxRepository).save(actual);
     }
@@ -175,7 +177,7 @@ class CollectInboxEntryProcessorTest {
         // then
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(CollectInboxStatus.FAILED),
-                () -> assertThat(actual.getFailureType()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED)
+                () -> assertThat(actual.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED)
         );
         verify(collectInboxRepository).save(actual);
     }
@@ -198,7 +200,7 @@ class CollectInboxEntryProcessorTest {
         collectInboxEntryProcessor.process(pending);
 
         // then
-        assertThat(actual.getFailureReason()).hasSize(500);
+        assertThat(actual.getFailure().reason()).hasSize(500);
         verify(collectInboxRepository).save(actual);
     }
 
@@ -220,16 +222,23 @@ class CollectInboxEntryProcessorTest {
         collectInboxEntryProcessor.process(pending);
 
         // then
-        assertThat(actual.getFailureReason()).isEqualTo("unknown failure");
+        assertThat(actual.getFailure().reason()).isEqualTo("unknown failure");
         verify(collectInboxRepository).save(actual);
     }
 
     private CollectInbox createProcessingInbox(long runId, int processingAttempt) {
-        CollectInbox inbox = CollectInbox.pending(
-                CollectInboxType.PULL_REQUEST_OPENED, 1L, runId, "{}"
-        );
-        ReflectionTestUtils.setField(inbox, "status", CollectInboxStatus.PROCESSING);
-        ReflectionTestUtils.setField(inbox, "processingAttempt", processingAttempt);
-        return inbox;
+        return CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(CollectInboxType.PULL_REQUEST_OPENED)
+                .projectId(1L)
+                .runId(runId)
+                .payloadJson("{}")
+                .status(CollectInboxStatus.PROCESSING)
+                .processingAttempt(processingAttempt)
+                .processingLease(BoxProcessingLease.claimed(Instant.parse("2026-03-16T00:00:00Z")))
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.absent())
+                .failure(CollectInboxFailureSnapshot.absent())
+                .build();
     }
 }

--- a/src/test/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxTest.java
+++ b/src/test/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.prism.statistics.infrastructure.common.BoxEventTime;
-import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureSnapshot;
 import com.prism.statistics.infrastructure.common.BoxProcessingLease;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -27,8 +26,10 @@ class CollectInboxTest {
 
     @Test
     void PENDING_상태의_inbox를_생성한다() {
+        // when
         CollectInbox inbox = CollectInbox.pending(TYPE, PROJECT_ID, RUN_ID, PAYLOAD_JSON);
 
+        // then
         assertAll(
                 () -> assertThat(inbox.getCollectType()).isEqualTo(TYPE),
                 () -> assertThat(inbox.getProjectId()).isEqualTo(PROJECT_ID),
@@ -45,30 +46,35 @@ class CollectInboxTest {
 
     @Test
     void pending_생성_시_collectType이_null이면_예외가_발생한다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.pending(null, PROJECT_ID, RUN_ID, PAYLOAD_JSON))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void pending_생성_시_runId가_0이면_예외가_발생한다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.pending(TYPE, PROJECT_ID, 0L, PAYLOAD_JSON))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void pending_생성_시_runId가_음수이면_예외가_발생한다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.pending(TYPE, PROJECT_ID, -1L, PAYLOAD_JSON))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void pending_생성_시_payloadJson이_null이면_예외가_발생한다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.pending(TYPE, PROJECT_ID, RUN_ID, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void rehydrate는_상태별_유효한_조합을_허용한다() {
+        // when & then
         assertAll(
                 () -> assertThatCode(this::createPendingInbox).doesNotThrowAnyException(),
                 () -> assertThatCode(this::createProcessingInbox).doesNotThrowAnyException(),
@@ -80,6 +86,7 @@ class CollectInboxTest {
 
     @Test
     void rehydrate_시_id가_null이면_예외가_발생한다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
                 .id(null)
                 .collectType(TYPE)
@@ -98,6 +105,7 @@ class CollectInboxTest {
 
     @Test
     void rehydrate_시_PROCESSING_상태는_claimed_lease가_필수다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
                 .id(1L)
                 .collectType(TYPE)
@@ -116,6 +124,7 @@ class CollectInboxTest {
 
     @Test
     void rehydrate_시_PROCESSED_상태는_processedTime이_필수다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
                 .id(1L)
                 .collectType(TYPE)
@@ -134,6 +143,7 @@ class CollectInboxTest {
 
     @Test
     void rehydrate_시_RETRY_PENDING_상태는_retry_pending용_failureType이_필수다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
                 .id(1L)
                 .collectType(TYPE)
@@ -152,6 +162,7 @@ class CollectInboxTest {
 
     @Test
     void rehydrate_시_FAILED_상태는_failed용_failureType이_필수다() {
+        // when & then
         assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
                 .id(1L)
                 .collectType(TYPE)
@@ -170,10 +181,13 @@ class CollectInboxTest {
 
     @Test
     void PROCESSING_상태에서_PROCESSED로_전이한다() {
+        // given
         CollectInbox inbox = createProcessingInbox();
 
+        // when
         inbox.markProcessed(PROCESSED_AT);
 
+        // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.PROCESSED),
                 () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
@@ -186,18 +200,23 @@ class CollectInboxTest {
 
     @Test
     void PENDING_상태에서_PROCESSED로_전이하면_예외가_발생한다() {
+        // given
         CollectInbox inbox = CollectInbox.pending(TYPE, PROJECT_ID, RUN_ID, PAYLOAD_JSON);
 
+        // when & then
         assertThatThrownBy(() -> inbox.markProcessed(PROCESSED_AT))
                 .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void PROCESSING_상태에서_RETRY_PENDING으로_전이한다() {
+        // given
         CollectInbox inbox = createProcessingInbox();
 
+        // when
         inbox.markRetryPending(FAILED_AT, "일시적 오류");
 
+        // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.RETRY_PENDING),
                 () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
@@ -210,16 +229,20 @@ class CollectInboxTest {
 
     @Test
     void markRetryPending_시_failureReason이_blank이면_예외가_발생한다() {
+        // given
         CollectInbox inbox = createProcessingInbox();
 
+        // when & then
         assertThatThrownBy(() -> inbox.markRetryPending(FAILED_AT, "  "))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void markRetryPending_시_failed용_failureType이면_예외가_발생한다() {
+        // given
         CollectInbox inbox = createProcessingInbox();
 
+        // when & then
         assertThatThrownBy(() -> inbox.markRetryPending(
                 FAILED_AT,
                 "일시적 오류",
@@ -229,10 +252,13 @@ class CollectInboxTest {
 
     @Test
     void PROCESSING_상태에서_BUSINESS_INVARIANT로_FAILED_전이한다() {
+        // given
         CollectInbox inbox = createProcessingInbox();
 
+        // when
         inbox.markFailed(FAILED_AT, "비즈니스 로직 실패", CollectInboxFailureType.BUSINESS_INVARIANT);
 
+        // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.FAILED),
                 () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
@@ -245,17 +271,22 @@ class CollectInboxTest {
 
     @Test
     void PROCESSING_상태에서_RETRY_EXHAUSTED로_FAILED_전이한다() {
+        // given
         CollectInbox inbox = createProcessingInbox();
 
+        // when
         inbox.markFailed(FAILED_AT, "재시도 횟수 초과", CollectInboxFailureType.RETRY_EXHAUSTED);
 
+        // then
         assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED);
     }
 
     @Test
     void PENDING_상태에서_FAILED로_전이하면_예외가_발생한다() {
+        // given
         CollectInbox inbox = CollectInbox.pending(TYPE, PROJECT_ID, RUN_ID, PAYLOAD_JSON);
 
+        // when & then
         assertThatThrownBy(() -> inbox.markFailed(
                 FAILED_AT,
                 "실패",
@@ -265,16 +296,20 @@ class CollectInboxTest {
 
     @Test
     void markFailed_시_failureType이_null이면_예외가_발생한다() {
+        // given
         CollectInbox inbox = createProcessingInbox();
 
+        // when & then
         assertThatThrownBy(() -> inbox.markFailed(FAILED_AT, "실패", null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void markFailed_시_retry_pending용_failureType이면_예외가_발생한다() {
+        // given
         CollectInbox inbox = createProcessingInbox();
 
+        // when & then
         assertThatThrownBy(() -> inbox.markFailed(FAILED_AT, "실패", CollectInboxFailureType.RETRYABLE))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/src/test/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxTest.java
+++ b/src/test/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxTest.java
@@ -76,11 +76,11 @@ class CollectInboxTest {
     void rehydrate는_상태별_유효한_조합을_허용한다() {
         // when & then
         assertAll(
-                () -> assertThatCode(this::createPendingInbox).doesNotThrowAnyException(),
-                () -> assertThatCode(this::createProcessingInbox).doesNotThrowAnyException(),
-                () -> assertThatCode(this::createProcessedInbox).doesNotThrowAnyException(),
-                () -> assertThatCode(this::createRetryPendingInbox).doesNotThrowAnyException(),
-                () -> assertThatCode(this::createFailedInbox).doesNotThrowAnyException()
+                () -> assertThatCode(() -> createPendingInbox()).doesNotThrowAnyException(),
+                () -> assertThatCode(() -> createProcessingInbox()).doesNotThrowAnyException(),
+                () -> assertThatCode(() -> createProcessedInbox()).doesNotThrowAnyException(),
+                () -> assertThatCode(() -> createRetryPendingInbox()).doesNotThrowAnyException(),
+                () -> assertThatCode(() -> createFailedInbox()).doesNotThrowAnyException()
         );
     }
 

--- a/src/test/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxTest.java
+++ b/src/test/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxTest.java
@@ -79,6 +79,24 @@ class CollectInboxTest {
     }
 
     @Test
+    void rehydrate_시_id가_null이면_예외가_발생한다() {
+        assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
+                .id(null)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.PENDING)
+                .processingAttempt(0)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.absent())
+                .failure(CollectInboxFailureSnapshot.absent())
+                .build()
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void rehydrate_시_PROCESSING_상태는_claimed_lease가_필수다() {
         assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
                 .id(1L)

--- a/src/test/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxTest.java
+++ b/src/test/java/com/prism/statistics/infrastructure/collect/inbox/CollectInboxTest.java
@@ -1,14 +1,17 @@
 package com.prism.statistics.infrastructure.collect.inbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.prism.statistics.infrastructure.common.BoxEventTime;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureSnapshot;
+import com.prism.statistics.infrastructure.common.BoxProcessingLease;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -18,20 +21,25 @@ class CollectInboxTest {
     private static final Long PROJECT_ID = 1L;
     private static final long RUN_ID = 12345678L;
     private static final String PAYLOAD_JSON = "{\"pullRequest\":{\"number\":1}}";
+    private static final Instant PROCESSING_STARTED_AT = Instant.parse("2026-03-16T00:00:00Z");
+    private static final Instant PROCESSED_AT = Instant.parse("2026-03-16T00:01:00Z");
+    private static final Instant FAILED_AT = Instant.parse("2026-03-16T00:02:00Z");
 
     @Test
     void PENDING_상태의_inbox를_생성한다() {
-        // when
         CollectInbox inbox = CollectInbox.pending(TYPE, PROJECT_ID, RUN_ID, PAYLOAD_JSON);
 
-        // then
         assertAll(
                 () -> assertThat(inbox.getCollectType()).isEqualTo(TYPE),
                 () -> assertThat(inbox.getProjectId()).isEqualTo(PROJECT_ID),
                 () -> assertThat(inbox.getRunId()).isEqualTo(RUN_ID),
                 () -> assertThat(inbox.getPayloadJson()).isEqualTo(PAYLOAD_JSON),
                 () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.PENDING),
-                () -> assertThat(inbox.getProcessingAttempt()).isZero()
+                () -> assertThat(inbox.getProcessingAttempt()).isZero(),
+                () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailure().isPresent()).isFalse()
         );
     }
 
@@ -60,121 +68,276 @@ class CollectInboxTest {
     }
 
     @Test
+    void rehydrate는_상태별_유효한_조합을_허용한다() {
+        assertAll(
+                () -> assertThatCode(this::createPendingInbox).doesNotThrowAnyException(),
+                () -> assertThatCode(this::createProcessingInbox).doesNotThrowAnyException(),
+                () -> assertThatCode(this::createProcessedInbox).doesNotThrowAnyException(),
+                () -> assertThatCode(this::createRetryPendingInbox).doesNotThrowAnyException(),
+                () -> assertThatCode(this::createFailedInbox).doesNotThrowAnyException()
+        );
+    }
+
+    @Test
+    void rehydrate_시_PROCESSING_상태는_claimed_lease가_필수다() {
+        assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.PROCESSING)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.absent())
+                .failure(CollectInboxFailureSnapshot.absent())
+                .build()
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rehydrate_시_PROCESSED_상태는_processedTime이_필수다() {
+        assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.PROCESSED)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.absent())
+                .failure(CollectInboxFailureSnapshot.absent())
+                .build()
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rehydrate_시_RETRY_PENDING_상태는_retry_pending용_failureType이_필수다() {
+        assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.RETRY_PENDING)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.present(FAILED_AT))
+                .failure(CollectInboxFailureSnapshot.present("실패", CollectInboxFailureType.BUSINESS_INVARIANT))
+                .build()
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rehydrate_시_FAILED_상태는_failed용_failureType이_필수다() {
+        assertThatThrownBy(() -> CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.FAILED)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.present(FAILED_AT))
+                .failure(CollectInboxFailureSnapshot.present("실패", CollectInboxFailureType.RETRYABLE))
+                .build()
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void PROCESSING_상태에서_PROCESSED로_전이한다() {
-        // given
         CollectInbox inbox = createProcessingInbox();
-        Instant now = Instant.now();
 
-        // when
-        inbox.markProcessed(now);
+        inbox.markProcessed(PROCESSED_AT);
 
-        // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.PROCESSED),
-                () -> assertThat(inbox.getProcessingStartedAt()).isNull(),
-                () -> assertThat(inbox.getProcessedAt()).isEqualTo(now),
-                () -> assertThat(inbox.getFailureReason()).isNull(),
-                () -> assertThat(inbox.getFailureType()).isNull()
+                () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isTrue(),
+                () -> assertThat(inbox.getProcessedTime().occurredAt()).isEqualTo(PROCESSED_AT),
+                () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailure().isPresent()).isFalse()
         );
     }
 
     @Test
     void PENDING_상태에서_PROCESSED로_전이하면_예외가_발생한다() {
-        // given
         CollectInbox inbox = CollectInbox.pending(TYPE, PROJECT_ID, RUN_ID, PAYLOAD_JSON);
 
-        // when & then
-        assertThatThrownBy(() -> inbox.markProcessed(Instant.now()))
+        assertThatThrownBy(() -> inbox.markProcessed(PROCESSED_AT))
                 .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void PROCESSING_상태에서_RETRY_PENDING으로_전이한다() {
-        // given
         CollectInbox inbox = createProcessingInbox();
-        Instant now = Instant.now();
 
-        // when
-        inbox.markRetryPending(now, "일시적 오류");
+        inbox.markRetryPending(FAILED_AT, "일시적 오류");
 
-        // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.RETRY_PENDING),
-                () -> assertThat(inbox.getProcessingStartedAt()).isNull(),
-                () -> assertThat(inbox.getFailedAt()).isEqualTo(now),
-                () -> assertThat(inbox.getFailureReason()).isEqualTo("일시적 오류"),
-                () -> assertThat(inbox.getFailureType()).isNull()
+                () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(FAILED_AT),
+                () -> assertThat(inbox.getFailure().reason()).isEqualTo("일시적 오류"),
+                () -> assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRYABLE)
         );
     }
 
     @Test
     void markRetryPending_시_failureReason이_blank이면_예외가_발생한다() {
-        // given
         CollectInbox inbox = createProcessingInbox();
-        Instant now = Instant.now();
 
-        // when & then
-        assertThatThrownBy(() -> inbox.markRetryPending(now, "  "))
+        assertThatThrownBy(() -> inbox.markRetryPending(FAILED_AT, "  "))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void PROCESSING_상태에서_BUSINESS_INVARIANT로_FAILED_전이한다() {
-        // given
+    void markRetryPending_시_failed용_failureType이면_예외가_발생한다() {
         CollectInbox inbox = createProcessingInbox();
-        Instant now = Instant.now();
 
-        // when
-        inbox.markFailed(now, "비즈니스 로직 실패", CollectInboxFailureType.BUSINESS_INVARIANT);
+        assertThatThrownBy(() -> inbox.markRetryPending(
+                FAILED_AT,
+                "일시적 오류",
+                CollectInboxFailureType.BUSINESS_INVARIANT
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
 
-        // then
+    @Test
+    void PROCESSING_상태에서_BUSINESS_INVARIANT로_FAILED_전이한다() {
+        CollectInbox inbox = createProcessingInbox();
+
+        inbox.markFailed(FAILED_AT, "비즈니스 로직 실패", CollectInboxFailureType.BUSINESS_INVARIANT);
+
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.FAILED),
-                () -> assertThat(inbox.getProcessingStartedAt()).isNull(),
-                () -> assertThat(inbox.getFailedAt()).isEqualTo(now),
-                () -> assertThat(inbox.getFailureReason()).isEqualTo("비즈니스 로직 실패"),
-                () -> assertThat(inbox.getFailureType()).isEqualTo(CollectInboxFailureType.BUSINESS_INVARIANT)
+                () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(FAILED_AT),
+                () -> assertThat(inbox.getFailure().reason()).isEqualTo("비즈니스 로직 실패"),
+                () -> assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.BUSINESS_INVARIANT)
         );
     }
 
     @Test
     void PROCESSING_상태에서_RETRY_EXHAUSTED로_FAILED_전이한다() {
-        // given
         CollectInbox inbox = createProcessingInbox();
-        Instant now = Instant.now();
 
-        // when
-        inbox.markFailed(now, "재시도 횟수 초과", CollectInboxFailureType.RETRY_EXHAUSTED);
+        inbox.markFailed(FAILED_AT, "재시도 횟수 초과", CollectInboxFailureType.RETRY_EXHAUSTED);
 
-        // then
-        assertThat(inbox.getFailureType()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED);
+        assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED);
     }
 
     @Test
     void PENDING_상태에서_FAILED로_전이하면_예외가_발생한다() {
-        // given
         CollectInbox inbox = CollectInbox.pending(TYPE, PROJECT_ID, RUN_ID, PAYLOAD_JSON);
 
-        // when & then
         assertThatThrownBy(() -> inbox.markFailed(
-                Instant.now(), "실패", CollectInboxFailureType.BUSINESS_INVARIANT
+                FAILED_AT,
+                "실패",
+                CollectInboxFailureType.BUSINESS_INVARIANT
         )).isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void markFailed_시_failureType이_null이면_예외가_발생한다() {
-        // given
         CollectInbox inbox = createProcessingInbox();
-        Instant now = Instant.now();
 
-        // when & then
-        assertThatThrownBy(() -> inbox.markFailed(now, "실패", null))
+        assertThatThrownBy(() -> inbox.markFailed(FAILED_AT, "실패", null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void markFailed_시_retry_pending용_failureType이면_예외가_발생한다() {
+        CollectInbox inbox = createProcessingInbox();
+
+        assertThatThrownBy(() -> inbox.markFailed(FAILED_AT, "실패", CollectInboxFailureType.RETRYABLE))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private CollectInbox createPendingInbox() {
+        return CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.PENDING)
+                .processingAttempt(0)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.absent())
+                .failure(CollectInboxFailureSnapshot.absent())
+                .build();
+    }
+
     private CollectInbox createProcessingInbox() {
-        CollectInbox inbox = CollectInbox.pending(TYPE, PROJECT_ID, RUN_ID, PAYLOAD_JSON);
-        ReflectionTestUtils.setField(inbox, "status", CollectInboxStatus.PROCESSING);
-        return inbox;
+        return CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.PROCESSING)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.claimed(PROCESSING_STARTED_AT))
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.absent())
+                .failure(CollectInboxFailureSnapshot.absent())
+                .build();
+    }
+
+    private CollectInbox createProcessedInbox() {
+        return CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.PROCESSED)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.present(PROCESSED_AT))
+                .failedTime(BoxEventTime.absent())
+                .failure(CollectInboxFailureSnapshot.absent())
+                .build();
+    }
+
+    private CollectInbox createRetryPendingInbox() {
+        return CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.RETRY_PENDING)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.present(FAILED_AT))
+                .failure(CollectInboxFailureSnapshot.present("일시적 오류", CollectInboxFailureType.RETRYABLE))
+                .build();
+    }
+
+    private CollectInbox createFailedInbox() {
+        return CollectInbox.rehydrateBuilder()
+                .id(1L)
+                .collectType(TYPE)
+                .projectId(PROJECT_ID)
+                .runId(RUN_ID)
+                .payloadJson(PAYLOAD_JSON)
+                .status(CollectInboxStatus.FAILED)
+                .processingAttempt(1)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.present(FAILED_AT))
+                .failure(CollectInboxFailureSnapshot.present("최종 실패", CollectInboxFailureType.BUSINESS_INVARIANT))
+                .build();
     }
 }

--- a/src/test/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxJpaEntityTest.java
+++ b/src/test/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxJpaEntityTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.prism.statistics.application.IntegrationTest;
 import com.prism.statistics.infrastructure.collect.inbox.CollectInbox;
 import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureType;
 import com.prism.statistics.infrastructure.collect.inbox.CollectInboxStatus;
@@ -14,80 +15,79 @@ import com.prism.statistics.infrastructure.common.BoxProcessingLease;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class CollectInboxJpaEntityTest {
 
-    private static final Instant PROCESSING_STARTED_AT = Instant.parse("2026-03-16T00:00:00Z");
-    private static final Instant PROCESSED_AT = Instant.parse("2026-03-16T00:01:00Z");
     private static final Instant FAILED_AT = Instant.parse("2026-03-16T00:02:00Z");
 
-    @Test
-    void toDomain은_null_컬럼을_absent_vo로_변환한다() {
-        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
-        ReflectionTestUtils.setField(entity, "id", 1L);
-        ReflectionTestUtils.setField(entity, "collectType", CollectInboxType.PULL_REQUEST_OPENED);
-        ReflectionTestUtils.setField(entity, "projectId", 1L);
-        ReflectionTestUtils.setField(entity, "runId", 10L);
-        ReflectionTestUtils.setField(entity, "payloadJson", "{}");
-        ReflectionTestUtils.setField(entity, "status", CollectInboxStatus.PENDING);
-        ReflectionTestUtils.setField(entity, "processingAttempt", 0);
+    @IntegrationTest
+    @Nested
+    class toDomain_통합_테스트 {
 
-        CollectInbox inbox = entity.toDomain();
+        @Autowired
+        private JpaCollectInboxRepository jpaCollectInboxRepository;
 
-        assertAll(
-                () -> assertThat(inbox.getId()).isEqualTo(1L),
-                () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
-                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
-                () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
-                () -> assertThat(inbox.getFailure().isPresent()).isFalse()
-        );
+        @Sql("/sql/collect/insert_pending_inbox.sql")
+        @Test
+        void toDomain은_null_컬럼을_absent_vo로_변환한다() {
+            // given
+            CollectInboxJpaEntity entity = jpaCollectInboxRepository.findById(1L).orElseThrow();
+
+            // when
+            CollectInbox inbox = entity.toDomain();
+
+            // then
+            assertAll(
+                    () -> assertThat(inbox.getId()).isEqualTo(1L),
+                    () -> assertThat(inbox.getCollectType()).isEqualTo(CollectInboxType.PULL_REQUEST_OPENED),
+                    () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.PENDING),
+                    () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
+                    () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                    () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
+                    () -> assertThat(inbox.getFailure().isPresent()).isFalse()
+            );
+        }
+
+        @Sql("/sql/collect/insert_failed_inbox.sql")
+        @Test
+        void toDomain은_present_vo를_복원한다() {
+            // given
+            CollectInboxJpaEntity entity = jpaCollectInboxRepository.findById(1L).orElseThrow();
+
+            // when
+            CollectInbox inbox = entity.toDomain();
+
+            // then
+            assertAll(
+                    () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(FAILED_AT),
+                    () -> assertThat(inbox.getFailure().reason()).isEqualTo("최종 실패"),
+                    () -> assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED)
+            );
+        }
     }
 
     @Test
-    void toDomain은_present_vo를_복원한다() {
-        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
-        ReflectionTestUtils.setField(entity, "id", 2L);
-        ReflectionTestUtils.setField(entity, "collectType", CollectInboxType.PULL_REQUEST_OPENED);
-        ReflectionTestUtils.setField(entity, "projectId", 1L);
-        ReflectionTestUtils.setField(entity, "runId", 20L);
-        ReflectionTestUtils.setField(entity, "payloadJson", "{}");
-        ReflectionTestUtils.setField(entity, "status", CollectInboxStatus.FAILED);
-        ReflectionTestUtils.setField(entity, "processingAttempt", 3);
-        ReflectionTestUtils.setField(entity, "failedAt", FAILED_AT);
-        ReflectionTestUtils.setField(entity, "failureReason", "최종 실패");
-        ReflectionTestUtils.setField(entity, "failureType", CollectInboxFailureType.RETRY_EXHAUSTED);
-
-        CollectInbox inbox = entity.toDomain();
-
-        assertAll(
-                () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(FAILED_AT),
-                () -> assertThat(inbox.getFailure().reason()).isEqualTo("최종 실패"),
-                () -> assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED)
-        );
-    }
-
-    @Test
-    void toDomain_시_failure_컬럼이_부분적으로만_채워져있으면_예외가_발생한다() {
-        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
-        ReflectionTestUtils.setField(entity, "collectType", CollectInboxType.PULL_REQUEST_OPENED);
-        ReflectionTestUtils.setField(entity, "projectId", 1L);
-        ReflectionTestUtils.setField(entity, "runId", 20L);
-        ReflectionTestUtils.setField(entity, "payloadJson", "{}");
-        ReflectionTestUtils.setField(entity, "status", CollectInboxStatus.FAILED);
-        ReflectionTestUtils.setField(entity, "processingAttempt", 1);
+    void toDomain_시_failureReason만_있고_failureType이_null이면_예외가_발생한다() {
+        // given
+        CollectInboxJpaEntity entity = createFailedEntity(null, 20L, 1);
         ReflectionTestUtils.setField(entity, "failedAt", FAILED_AT);
         ReflectionTestUtils.setField(entity, "failureReason", "실패");
 
+        // when & then
         assertThatThrownBy(entity::toDomain)
                 .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void apply는_absent_vo를_null_컬럼으로_반영한다() {
+        // given
         CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
         CollectInbox inbox = CollectInbox.pending(
                 CollectInboxType.PULL_REQUEST_OPENED,
@@ -96,8 +96,10 @@ class CollectInboxJpaEntityTest {
                 "{}"
         );
 
+        // when
         entity.apply(inbox);
 
+        // then
         assertAll(
                 () -> assertThat(ReflectionTestUtils.getField(entity, "processingStartedAt")).isNull(),
                 () -> assertThat(ReflectionTestUtils.getField(entity, "processedAt")).isNull(),
@@ -109,6 +111,7 @@ class CollectInboxJpaEntityTest {
 
     @Test
     void apply는_present_vo를_컬럼에_반영한다() {
+        // given
         CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
         CollectInbox inbox = CollectInbox.rehydrateBuilder()
                 .id(3L)
@@ -124,8 +127,10 @@ class CollectInboxJpaEntityTest {
                 .failure(CollectInboxFailureSnapshot.present("타임아웃", CollectInboxFailureType.PROCESSING_TIMEOUT))
                 .build();
 
+        // when
         entity.apply(inbox);
 
+        // then
         assertAll(
                 () -> assertThat(ReflectionTestUtils.getField(entity, "processingStartedAt")).isNull(),
                 () -> assertThat(ReflectionTestUtils.getField(entity, "processedAt")).isNull(),
@@ -134,5 +139,17 @@ class CollectInboxJpaEntityTest {
                 () -> assertThat(ReflectionTestUtils.getField(entity, "failureType"))
                         .isEqualTo(CollectInboxFailureType.PROCESSING_TIMEOUT)
         );
+    }
+
+    private CollectInboxJpaEntity createFailedEntity(Long id, long runId, int processingAttempt) {
+        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
+        ReflectionTestUtils.setField(entity, "id", id);
+        ReflectionTestUtils.setField(entity, "collectType", CollectInboxType.PULL_REQUEST_OPENED);
+        ReflectionTestUtils.setField(entity, "projectId", 1L);
+        ReflectionTestUtils.setField(entity, "runId", runId);
+        ReflectionTestUtils.setField(entity, "payloadJson", "{}");
+        ReflectionTestUtils.setField(entity, "status", CollectInboxStatus.FAILED);
+        ReflectionTestUtils.setField(entity, "processingAttempt", processingAttempt);
+        return entity;
     }
 }

--- a/src/test/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxJpaEntityTest.java
+++ b/src/test/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxJpaEntityTest.java
@@ -1,0 +1,138 @@
+package com.prism.statistics.infrastructure.collect.inbox.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.prism.statistics.infrastructure.collect.inbox.CollectInbox;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureType;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxStatus;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxType;
+import com.prism.statistics.infrastructure.common.BoxEventTime;
+import com.prism.statistics.infrastructure.collect.inbox.CollectInboxFailureSnapshot;
+import com.prism.statistics.infrastructure.common.BoxProcessingLease;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CollectInboxJpaEntityTest {
+
+    private static final Instant PROCESSING_STARTED_AT = Instant.parse("2026-03-16T00:00:00Z");
+    private static final Instant PROCESSED_AT = Instant.parse("2026-03-16T00:01:00Z");
+    private static final Instant FAILED_AT = Instant.parse("2026-03-16T00:02:00Z");
+
+    @Test
+    void toDomain은_null_컬럼을_absent_vo로_변환한다() {
+        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
+        ReflectionTestUtils.setField(entity, "id", 1L);
+        ReflectionTestUtils.setField(entity, "collectType", CollectInboxType.PULL_REQUEST_OPENED);
+        ReflectionTestUtils.setField(entity, "projectId", 1L);
+        ReflectionTestUtils.setField(entity, "runId", 10L);
+        ReflectionTestUtils.setField(entity, "payloadJson", "{}");
+        ReflectionTestUtils.setField(entity, "status", CollectInboxStatus.PENDING);
+        ReflectionTestUtils.setField(entity, "processingAttempt", 0);
+
+        CollectInbox inbox = entity.toDomain();
+
+        assertAll(
+                () -> assertThat(inbox.getId()).isEqualTo(1L),
+                () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailure().isPresent()).isFalse()
+        );
+    }
+
+    @Test
+    void toDomain은_present_vo를_복원한다() {
+        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
+        ReflectionTestUtils.setField(entity, "id", 2L);
+        ReflectionTestUtils.setField(entity, "collectType", CollectInboxType.PULL_REQUEST_OPENED);
+        ReflectionTestUtils.setField(entity, "projectId", 1L);
+        ReflectionTestUtils.setField(entity, "runId", 20L);
+        ReflectionTestUtils.setField(entity, "payloadJson", "{}");
+        ReflectionTestUtils.setField(entity, "status", CollectInboxStatus.FAILED);
+        ReflectionTestUtils.setField(entity, "processingAttempt", 3);
+        ReflectionTestUtils.setField(entity, "failedAt", FAILED_AT);
+        ReflectionTestUtils.setField(entity, "failureReason", "최종 실패");
+        ReflectionTestUtils.setField(entity, "failureType", CollectInboxFailureType.RETRY_EXHAUSTED);
+
+        CollectInbox inbox = entity.toDomain();
+
+        assertAll(
+                () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(FAILED_AT),
+                () -> assertThat(inbox.getFailure().reason()).isEqualTo("최종 실패"),
+                () -> assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED)
+        );
+    }
+
+    @Test
+    void toDomain_시_failure_컬럼이_부분적으로만_채워져있으면_예외가_발생한다() {
+        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
+        ReflectionTestUtils.setField(entity, "collectType", CollectInboxType.PULL_REQUEST_OPENED);
+        ReflectionTestUtils.setField(entity, "projectId", 1L);
+        ReflectionTestUtils.setField(entity, "runId", 20L);
+        ReflectionTestUtils.setField(entity, "payloadJson", "{}");
+        ReflectionTestUtils.setField(entity, "status", CollectInboxStatus.FAILED);
+        ReflectionTestUtils.setField(entity, "processingAttempt", 1);
+        ReflectionTestUtils.setField(entity, "failedAt", FAILED_AT);
+        ReflectionTestUtils.setField(entity, "failureReason", "실패");
+
+        assertThatThrownBy(entity::toDomain)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void apply는_absent_vo를_null_컬럼으로_반영한다() {
+        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
+        CollectInbox inbox = CollectInbox.pending(
+                CollectInboxType.PULL_REQUEST_OPENED,
+                1L,
+                10L,
+                "{}"
+        );
+
+        entity.apply(inbox);
+
+        assertAll(
+                () -> assertThat(ReflectionTestUtils.getField(entity, "processingStartedAt")).isNull(),
+                () -> assertThat(ReflectionTestUtils.getField(entity, "processedAt")).isNull(),
+                () -> assertThat(ReflectionTestUtils.getField(entity, "failedAt")).isNull(),
+                () -> assertThat(ReflectionTestUtils.getField(entity, "failureReason")).isNull(),
+                () -> assertThat(ReflectionTestUtils.getField(entity, "failureType")).isNull()
+        );
+    }
+
+    @Test
+    void apply는_present_vo를_컬럼에_반영한다() {
+        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
+        CollectInbox inbox = CollectInbox.rehydrateBuilder()
+                .id(3L)
+                .collectType(CollectInboxType.PULL_REQUEST_OPENED)
+                .projectId(1L)
+                .runId(30L)
+                .payloadJson("{}")
+                .status(CollectInboxStatus.RETRY_PENDING)
+                .processingAttempt(2)
+                .processingLease(BoxProcessingLease.idle())
+                .processedTime(BoxEventTime.absent())
+                .failedTime(BoxEventTime.present(FAILED_AT))
+                .failure(CollectInboxFailureSnapshot.present("타임아웃", CollectInboxFailureType.PROCESSING_TIMEOUT))
+                .build();
+
+        entity.apply(inbox);
+
+        assertAll(
+                () -> assertThat(ReflectionTestUtils.getField(entity, "processingStartedAt")).isNull(),
+                () -> assertThat(ReflectionTestUtils.getField(entity, "processedAt")).isNull(),
+                () -> assertThat(ReflectionTestUtils.getField(entity, "failedAt")).isEqualTo(FAILED_AT),
+                () -> assertThat(ReflectionTestUtils.getField(entity, "failureReason")).isEqualTo("타임아웃"),
+                () -> assertThat(ReflectionTestUtils.getField(entity, "failureType"))
+                        .isEqualTo(CollectInboxFailureType.PROCESSING_TIMEOUT)
+        );
+    }
+}

--- a/src/test/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxJpaEntityTest.java
+++ b/src/test/java/com/prism/statistics/infrastructure/collect/inbox/persistence/CollectInboxJpaEntityTest.java
@@ -15,74 +15,59 @@ import com.prism.statistics.infrastructure.common.BoxProcessingLease;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.util.ReflectionTestUtils;
 
+@IntegrationTest
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class CollectInboxJpaEntityTest {
 
     private static final Instant FAILED_AT = Instant.parse("2026-03-16T00:02:00Z");
 
-    @IntegrationTest
-    @Nested
-    class toDomain_통합_테스트 {
+    @Autowired
+    private CollectInboxRepositoryAdapter collectInboxRepositoryAdapter;
 
-        @Autowired
-        private JpaCollectInboxRepository jpaCollectInboxRepository;
+    @Sql("/sql/collect/insert_pending_inbox.sql")
+    @Test
+    void toDomain은_null_컬럼을_absent_vo로_변환한다() {
+        // when
+        CollectInbox inbox = collectInboxRepositoryAdapter.findById(1L).orElseThrow();
 
-        @Sql("/sql/collect/insert_pending_inbox.sql")
-        @Test
-        void toDomain은_null_컬럼을_absent_vo로_변환한다() {
-            // given
-            CollectInboxJpaEntity entity = jpaCollectInboxRepository.findById(1L).orElseThrow();
-
-            // when
-            CollectInbox inbox = entity.toDomain();
-
-            // then
-            assertAll(
-                    () -> assertThat(inbox.getId()).isEqualTo(1L),
-                    () -> assertThat(inbox.getCollectType()).isEqualTo(CollectInboxType.PULL_REQUEST_OPENED),
-                    () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.PENDING),
-                    () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
-                    () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
-                    () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
-                    () -> assertThat(inbox.getFailure().isPresent()).isFalse()
-            );
-        }
-
-        @Sql("/sql/collect/insert_failed_inbox.sql")
-        @Test
-        void toDomain은_present_vo를_복원한다() {
-            // given
-            CollectInboxJpaEntity entity = jpaCollectInboxRepository.findById(1L).orElseThrow();
-
-            // when
-            CollectInbox inbox = entity.toDomain();
-
-            // then
-            assertAll(
-                    () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(FAILED_AT),
-                    () -> assertThat(inbox.getFailure().reason()).isEqualTo("최종 실패"),
-                    () -> assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED)
-            );
-        }
+        // then
+        assertAll(
+                () -> assertThat(inbox.getId()).isEqualTo(1L),
+                () -> assertThat(inbox.getCollectType()).isEqualTo(CollectInboxType.PULL_REQUEST_OPENED),
+                () -> assertThat(inbox.getStatus()).isEqualTo(CollectInboxStatus.PENDING),
+                () -> assertThat(inbox.getProcessingLease().isClaimed()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailure().isPresent()).isFalse()
+        );
     }
 
+    @Sql("/sql/collect/insert_failed_inbox.sql")
+    @Test
+    void toDomain은_present_vo를_복원한다() {
+        // when
+        CollectInbox inbox = collectInboxRepositoryAdapter.findById(1L).orElseThrow();
+
+        // then
+        assertAll(
+                () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(FAILED_AT),
+                () -> assertThat(inbox.getFailure().reason()).isEqualTo("최종 실패"),
+                () -> assertThat(inbox.getFailure().type()).isEqualTo(CollectInboxFailureType.RETRY_EXHAUSTED)
+        );
+    }
+
+    @Sql("/sql/collect/insert_partial_failure_inbox.sql")
     @Test
     void toDomain_시_failureReason만_있고_failureType이_null이면_예외가_발생한다() {
-        // given
-        CollectInboxJpaEntity entity = createFailedEntity(null, 20L, 1);
-        ReflectionTestUtils.setField(entity, "failedAt", FAILED_AT);
-        ReflectionTestUtils.setField(entity, "failureReason", "실패");
-
         // when & then
-        assertThatThrownBy(entity::toDomain)
-                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> collectInboxRepositoryAdapter.findById(1L))
+                .hasCauseInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -139,17 +124,5 @@ class CollectInboxJpaEntityTest {
                 () -> assertThat(ReflectionTestUtils.getField(entity, "failureType"))
                         .isEqualTo(CollectInboxFailureType.PROCESSING_TIMEOUT)
         );
-    }
-
-    private CollectInboxJpaEntity createFailedEntity(Long id, long runId, int processingAttempt) {
-        CollectInboxJpaEntity entity = new CollectInboxJpaEntity();
-        ReflectionTestUtils.setField(entity, "id", id);
-        ReflectionTestUtils.setField(entity, "collectType", CollectInboxType.PULL_REQUEST_OPENED);
-        ReflectionTestUtils.setField(entity, "projectId", 1L);
-        ReflectionTestUtils.setField(entity, "runId", runId);
-        ReflectionTestUtils.setField(entity, "payloadJson", "{}");
-        ReflectionTestUtils.setField(entity, "status", CollectInboxStatus.FAILED);
-        ReflectionTestUtils.setField(entity, "processingAttempt", processingAttempt);
-        return entity;
     }
 }

--- a/src/test/resources/sql/cleanup.sql
+++ b/src/test/resources/sql/cleanup.sql
@@ -1,5 +1,6 @@
 SET REFERENTIAL_INTEGRITY FALSE;
 
+TRUNCATE TABLE collect_inbox;
 TRUNCATE TABLE review_comments;
 TRUNCATE TABLE reviews;
 TRUNCATE TABLE requested_reviewer_histories;

--- a/src/test/resources/sql/collect/insert_failed_inbox.sql
+++ b/src/test/resources/sql/collect/insert_failed_inbox.sql
@@ -1,0 +1,2 @@
+INSERT INTO collect_inbox (id, created_at, updated_at, collect_type, project_id, run_id, payload_json, status, processing_attempt, failed_at, failure_reason, failure_type)
+VALUES (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'PULL_REQUEST_OPENED', 1, 20, '{}', 'FAILED', 3, '2026-03-16T00:02:00Z', '최종 실패', 'RETRY_EXHAUSTED');

--- a/src/test/resources/sql/collect/insert_partial_failure_inbox.sql
+++ b/src/test/resources/sql/collect/insert_partial_failure_inbox.sql
@@ -1,0 +1,2 @@
+INSERT INTO collect_inbox (id, created_at, updated_at, collect_type, project_id, run_id, payload_json, status, processing_attempt, failed_at, failure_reason)
+VALUES (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'PULL_REQUEST_OPENED', 1, 20, '{}', 'FAILED', 1, '2026-03-16T00:02:00Z', '실패');

--- a/src/test/resources/sql/collect/insert_pending_inbox.sql
+++ b/src/test/resources/sql/collect/insert_pending_inbox.sql
@@ -1,0 +1,2 @@
+INSERT INTO collect_inbox (id, created_at, updated_at, collect_type, project_id, run_id, payload_json, status, processing_attempt)
+VALUES (1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'PULL_REQUEST_OPENED', 1, 10, '{}', 'PENDING', 0);


### PR DESCRIPTION
# 관련 이슈 번호
- closed #144 

## 이 PR을 통해 해결하려는 문제가 무엇인가요?

`CollectInbox`가 JPA 엔티티 역할과 도메인 상태 관리 역할을 함께 가지고 있어, 상태 전이 규칙과 영속성 매핑 책임이 한 클래스에 섞여 있었습니다.
이 때문에 `rehydrate` 과정에서 복원 상태의 유효성을 명확하게 검증하기 어렵고, persistence 레이어에서도 도메인 규칙이 드러나지 않는 문제가 있었습니다.

이번 PR은 `CollectInbox`를 도메인 객체로 분리하고, `CollectInboxJpaEntity`를 별도로 도입해서 도메인 상태 복원과 JPA 매핑 책임을 분리하는 것을 목표로 했습니다.

## 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

- `CollectInbox`를 JPA 엔티티에서 분리해 순수 도메인 객체로 변경했습니다.
- `CollectInboxJpaEntity`를 새로 추가하고, `toDomain()` / `apply()`를 통해 도메인 객체와 영속 상태를 변환하도록 정리했습니다.
- `CollectInbox` 복원 시 `rehydrateBuilder()`를 통해 상태를 조립하도록 바꾸고, `build()` 시점에 기존 `rehydrate` 검증 로직이 그대로 수행되도록 구성했습니다.
- `PENDING`, `PROCESSING`, `PROCESSED`, `RETRY_PENDING`, `FAILED` 상태별로 `processingLease`, `processedTime`, `failedTime`, `failure` 조합이 올바른지 검증
하는 불변식 로직을 추가했습니다.
- `RETRY_PENDING`과 `FAILED`에서 허용되는 `failureType`을 분리해서 검증하도록 정리했습니다.
- repository / creator / repository adapter가 새 `CollectInboxJpaEntity`를 기준으로 저장 및 조회하도록 수정했습니다.

## 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

- `CollectInbox` 관련 단위 테스트를 보강했습니다.
- `CollectInboxJpaEntity`의 `toDomain()` / `apply()` 매핑을 검증하는 테스트를 추가했습니다.

## Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

- 파라미터가 많은 `rehydrate`는 팀 컨벤션에 맞춰 `rehydrateBuilder()`로 바꿨습니다. 이 builder 진입 방식과 네이밍이 적절한지도 의견 부탁드립니다.
 ### rehydrateBuilder 설계

  Lombok `@Builder`를 **private static 메서드**에 걸어서 사용했습니다:

  ```java
  @Builder(builderMethodName = "rehydrateBuilder")
  private static CollectInbox rehydrate(...) { ... }
```
  - pending() 팩토리 메서드 = 새 inbox 생성 (유일한 생성 경로)
  - rehydrateBuilder() = DB에서 복원할 때만 사용 (JpaEntity.toDomain에서 호출)

  이렇게 한 이유:
  - 생성자에 @Builder를 걸면 pending()과 역할이 겹치고, 외부에서 임의 상태 조합으로 생성할 수 있게 됨
  - 클래스에 @Builder를 걸면 setter 느낌의 builder가 노출되어 도메인 의도가 흐려짐
  - private static 메서드에 걸면 빌더 이름(rehydrateBuilder)으로 용도가 명확하고, 내부에서 상태 불변식 검증을 강제할 수 있음

  이 접근이 적절한지, 혹은 더 나은 방법이 있는지 의견 부탁드립니다.
